### PR TITLE
Visual markers for visited maps

### DIFF
--- a/client.qc
+++ b/client.qc
@@ -44,6 +44,7 @@ void() SetChangeParms =
 	parm7 = self.ammo_cells;
 	parm8 = self.weapon;
 	parm9 = self.armortype * 100;
+	parm10 = self.visitflag;
 };
 
 void() SetNewParms =
@@ -92,6 +93,43 @@ void() DecodeLevelParms =
 	self.ammo_cells = parm7;
 	self.weapon = parm8;
 	self.armortype = parm9 * 0.01;
+	self.visitflag = parm10;
+	
+	//Inky 20221029 Handling visited maps
+	if (world.model == "maps/start.bsp")
+	{
+		//Identify all the trigger_changelevel entities and give them a unique visitflag id.
+		float num, fv;
+		entity portal,marker;
+		
+		entity oself = self;
+		
+		//Start the loop
+		num = 1;
+		portal = find (world, classname, "trigger_changelevel");
+		
+		while (portal != world && num <= 24) //24 is the maximum number of flag values a float can hold
+		{
+			fv = flag_value(num);
+			if (parm10 & fv)
+			{
+				//The destination map was visited already, let's fire its targets
+				self = portal;
+				SUB_UseTargets();
+			}
+			else
+			{
+				//The destination map was not visited yet. Let's give it a visitflag value so that it can notify the server when it's visited.
+				portal.visitflag = num;
+			}
+			
+			//Next one
+			num++;
+			portal = find (portal, classname, "trigger_changelevel");
+		}
+		
+		self = oself;
+	}
 };
 
 void(entity client, string savename) autosave =
@@ -221,8 +259,8 @@ entity() SelectSpawnPoint =
 		}
 	}
 
-	if (serverflags)
-	{	// return with a rune to start
+	if (serverflags || (world.model == "maps/start.bsp" && parm10 > 0))
+	{	// return with a rune to start or after having visited a map
 		spot = find (world, classname, "info_player_start2");
 		if (spot)
 			return spot;

--- a/defs.qc
+++ b/defs.qc
@@ -1108,3 +1108,6 @@ void(entity client, float density, vector color) csf_set;
 .float anchored;
 .entity nexthook;
 .float prepared;
+
+//Inky 20221029 Visited maps handling
+.float visitflag;

--- a/intermission.qc
+++ b/intermission.qc
@@ -314,6 +314,36 @@ void() execute_changelevel =
 	WriteByte (MSG_ALL, SVC_INTERMISSION);
 };
 
+float flag_value(float d) //Inky 20221025 Used for trigger_serverflags
+{
+	switch(d)
+	{
+		case  1: return 1; break;
+		case  2: return 2; break;
+		case  3: return 4; break;
+		case  4: return 8; break;
+		case  5: return 16; break;
+		case  6: return 32; break;
+		case  7: return 64; break;
+		case  8: return 128; break;
+		case  9: return 256; break;
+		case 10: return 512; break;
+		case 11: return 1024; break;
+		case 12: return 2048; break;
+		case 13: return 4096; break;
+		case 14: return 8192; break;
+		case 15: return 16384; break;
+		case 16: return 32768; break;
+		case 17: return 65536; break;
+		case 18: return 131072; break;
+		case 19: return 262144; break;
+		case 20: return 524288; break;
+		case 21: return 1048576; break;
+		case 22: return 2097152; break;
+		case 23: return 4194304; break;
+		case 24: return 8388608; break;
+	}
+}
 
 void() changelevel_touch =
 {
@@ -341,6 +371,13 @@ void() changelevel_touch =
 	sigil_touch2();
 	}
 
+	//Inky 20221029
+	if (self.visitflag >= 1 && self.visitflag <= 24)
+	{
+		float fv = flag_value(self.visitflag);
+		other.visitflag = other.visitflag | fv;
+	}
+	
 	if ( (self.spawnflags & 1) && (deathmatch == 0) )
 	{	// NO_INTERMISSION
 		GotoNextMap();


### PR DESCRIPTION
Native handling of visual markers for already visited portals in start.bsp + no more rune needed to jump to info_player_start2 once at least 1 map was visited