### PR TITLE
Ammunition inventory check

### DIFF
--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -1733,6 +1733,11 @@ Also, the state of the last evaluation is stored in this entity's 'state' field 
 		10 : "items (flag, use 'aflags' field)"
 		11 : "count (float, use 'count' field)"
 		12 : "cnt (float, use 'count' field)"
+		13 : "type (string, use 'type' field)"
+		14 : "ammo_shells (float, use 'count' field)"
+		15 : "ammo_nails (float, use 'count' field)"
+		16 : "ammo_rockets (float, use 'count' field)"
+		17 : "ammo_cells (float, use 'count' field)"
 	]
 	weapon(choices) : "Operation" : 0 = [
 		0 : "== (equal, valid for all fields)"

--- a/triggers.qc
+++ b/triggers.qc
@@ -1596,6 +1596,26 @@ void() trigger_filter_use = {
 			fieldtype = FILTER_FIELDTYPE_STRING;
 			targstring = targ.type;
 			break;
+
+		case /*ammo_shells*/14:
+			fieldtype = FILTER_FIELDTYPE_FLOAT;
+			targfloat = targ.ammo_shells;
+			break;
+			
+		case /*ammo_nails*/15:
+			fieldtype = FILTER_FIELDTYPE_FLOAT;
+			targfloat = targ.ammo_nails;
+			break;
+			
+		case /*ammo_rockets*/16:
+			fieldtype = FILTER_FIELDTYPE_FLOAT;
+			targfloat = targ.ammo_rockets;
+			break;
+			
+		case /*ammo_cells*/17:
+			fieldtype = FILTER_FIELDTYPE_FLOAT;
+			targfloat = targ.ammo_cells;
+			break;
 	}
 
 	if (fieldtype == FILTER_FIELDTYPE_FLOAT) {


### PR DESCRIPTION
trigger_filter was unable to check the player inventory to know what amount of ammunition of each type they had of each type.
Useful if as a mapper you want to base a trick on a certain type of projectile (like a grenade shaft) and need to be sure the player has nades left (otherwise you can trigger the spawning of a nade box).
Or if in a combat-heavy arena you want to keep track of the ammo inventory to spawn goodies when the supplies are running low below a certain threshold, etc.

Incidental fix: the fgd file didn't mention trigger_filter's ability to check the **type** field.
Caveat: def file not updated as it was not even featuring the trigger_filter entity?! 😲 Does anyone really care about def files???