### PR TITLE
Fix misc_model

### DIFF
--- a/misc_model.qc
+++ b/misc_model.qc
@@ -135,7 +135,7 @@ void() misc_model = {
  */
 void() misc_model_think = {
     self.nextthink = time + fabs(self.speed);
-    if (self.estate != STATE_ACTIVE) return;
+    if (self.estate != STATE_ACTIVE || self.state != STATE_ACTIVE) return;
     
     self.frame = self.frame + sign(self.speed);
 


### PR DESCRIPTION
pd3's estate status property messed up with misc_model's state property. Animations meant to be in awaiting state would therefore be run ahead of time.
Could be experienced with a misc_model spawnflagged as 'Only once' and 'Start hidden'. The settings are handled in .state whereas the think function checked .estate only. So .state was basically ignored and the animation was run right away while the model was still invisible (due to 'Start hidden') and when the model was triggered to appear, it was stuck on its last frame since the animation had been run already (and would never be run again due to 'Only once'), instead of starting its animation upon appearance.