### PR TITLE
Player on ground mesh event fix + .frame check + fgd update

### DIFF
--- a/client.qc
+++ b/client.qc
@@ -894,6 +894,20 @@ void() PlayerPreThink =
 			return;        // intermission or finale
 	}
 
+	if (!self.onWiremesh)
+	{
+		//Fire wiremesh targets on climbing mode change
+		if(self.state & STATE_RM_CLIMBING)
+		{
+			self.state = self.state - (self.state & STATE_RM_CLIMBING);
+			activator = self;
+			entity oself = self;
+			self = self.wiremesh;
+			SUB_UseTargets();
+			self = oself;
+		}
+	}
+
 	// note that this code block is here, before the tests which check
 	// whether the player is dead, so that the player's gravity will be
 	// correctly updated even if they e.g. fell off a ladder because
@@ -913,20 +927,10 @@ void() PlayerPreThink =
 	else
 	{
 		do_ladder_physics = FALSE;
+		do_wiremesh_physics = FALSE;
 		self.gravity = self.wantedgravity;
-		
-		//Fire wiremesh targets on climbing mode change
-		if(self.state & STATE_RM_CLIMBING)
-		{
-			self.state = self.state - (self.state & STATE_RM_CLIMBING);
-			activator = self;
-			entity oself = self;
-			self = self.wiremesh;
-			SUB_UseTargets();
-			self = oself;
-		}
 	}
-
+	
 	// If just spawned in, try to recover previous fog values from own client entity, if any
 	if (cleanUpClientStuff)
 		fog_setFromEnt(self, self);

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -1612,7 +1612,7 @@ When player is touching this entity, she can climb by pushing jump."
 	angle(integer) : "the direction player must be facing to climb ladder"
 ]
 
-@SolidClass base(Appearflags) = trigger_trampoline : "Invisible trampoline entity.
+@SolidClass base(Appearflags, Target) = trigger_trampoline : "Invisible trampoline entity.
 
 Player will bounce off of this like a trampoline, reflecting velocity."
 [
@@ -1638,7 +1638,7 @@ Player will bounce off of this like a trampoline, reflecting velocity."
 	]
 ]
 
-@SolidClass base(Appearflags) = trigger_wiremesh : "Invisible wiremesh entity.
+@SolidClass base(Appearflags, Target) = trigger_wiremesh : "Invisible wiremesh entity.
 
 Player can move freely inside of this entity's volume, on walls and ceilings."
 [
@@ -1747,6 +1747,7 @@ Also, the state of the last evaluation is stored in this entity's 'state' field 
 		16 : "ammo_rockets (float, use 'count' field)"
 		17 : "ammo_cells (float, use 'count' field)"
 		18 : "maxbounce (float, use 'count' field)"
+		19 : "frame (float, use 'count' field)"
 	]
 	weapon(choices) : "Operation" : 0 = [
 		0 : "== (equal, valid for all fields)"

--- a/rm_mechanics.qc
+++ b/rm_mechanics.qc
@@ -131,7 +131,7 @@ void() wiremesh_touch =
 	other.wiremesh = self;
 	
 	//Fire wiremesh targets on climbing mode change
-	if(!other.state & STATE_RM_CLIMBING)
+	if(!other.state & STATE_RM_CLIMBING && !other.flags & FL_ONGROUND)
 	{
 		other.state |= STATE_RM_CLIMBING;
 		activator = other;

--- a/triggers.qc
+++ b/triggers.qc
@@ -1712,6 +1712,11 @@ void() trigger_filter_use = {
 			fieldtype = FILTER_FIELDTYPE_FLOAT;
 			targfloat = targ.maxbounce;
 			break;
+			
+		case /*frame*/19:
+			fieldtype = FILTER_FIELDTYPE_FLOAT;
+			targfloat = targ.frame;
+			break;
 	}
 
 	if (fieldtype == FILTER_FIELDTYPE_FLOAT) {


### PR DESCRIPTION
- Player unduly entering climbing mode whereas still on ground fixed
- Targets added to fgd definitions of trampoline & wiremesh
- trigger_filter now able to check the .frame property (notably useful to trigger something when a misc_model has accomplished an animation sequence)