### PR TITLE
Lightpanel events

### DIFF
--- a/client.qc
+++ b/client.qc
@@ -880,7 +880,7 @@ void() CheckGrapple =
 		self.state = self.state - (self.state & STATE_RM_UNAIMING);
 	}
 	
-	if (self.impulse==24 && !self.hook_out) {
+	if (self.impulse==24 && !self.hook_out && !trace_ent.spawnflags & /*Aim only*/1) {
 		W_FireGrapple();
 		
 		//Fire lightpanel targets on hooking

--- a/client.qc
+++ b/client.qc
@@ -824,7 +824,7 @@ void() CheckGrapple =
 	
 	traceline(player_offset, (player_offset + (v_forward * 10000)), FALSE, self);
 	
-	local	entity new;
+	local	entity new, oself;
 	local	float dist;
 	local	vector panel_origin;
 	local	vector player_aim;
@@ -854,13 +854,47 @@ void() CheckGrapple =
 		new.think = SUB_Remove;
 		new.ltime = time;
 		new.nextthink = time + 0.02;
+		
+		//Fire lightpanel targets on entering aiming mode
+		if(!self.state & STATE_RM_AIMING)
+		{
+			self.state |= STATE_RM_AIMING;
+			self.rotatecontroller = trace_ent; //The .rotatecontroller property is reused in the lightpanel context to keep trace of what lightpanel was aimed at upon exiting aiming state (see if case below)
+			activator = self;
+			oself = self;
+			self = trace_ent;
+			SUB_UseTargets();
+			self = oself;
+		}
 	}
-	
+	else if(self.state & STATE_RM_AIMING && self.rotatecontroller) //Fire lightpanel targets on exiting aiming mode
+	{
+		self.state = self.state - (self.state & STATE_RM_AIMING);
+		self.state |= STATE_RM_UNAIMING;
+		activator = self;
+		oself = self;
+		self = self.rotatecontroller;
+		SUB_UseTargets();
+		self = oself;
+		self.rotatecontroller = world;
+		self.state = self.state - (self.state & STATE_RM_UNAIMING);
+	}
 	
 	if (self.impulse==24 && !self.hook_out) {
 		W_FireGrapple();
+		
+		//Fire lightpanel targets on hooking
+		if(self.state & STATE_RM_AIMING && (!self.state & STATE_RM_HOOKING))
+		{
+			self.state = self.state - (self.state & STATE_RM_AIMING);
+			self.state |= STATE_RM_HOOKING;
+			activator = self;
+			oself = self;
+			self = trace_ent;
+			SUB_UseTargets();
+			self = oself;
+		}
 	}
-
 
 }
 

--- a/defs.qc
+++ b/defs.qc
@@ -973,10 +973,13 @@ float STATE_ACTIVE      = 0;
 float STATE_INACTIVE    = 1;
 float STATE_INVISIBLE = 8;
 //Re:Mobilize states
-float STATE_RM_CUSHIONED =  2; //Trampoline
-float STATE_RM_BOUNCING  =  4; //Trampoline
-float STATE_RM_CLIMBING  = 16; //Wiremesh
-
+float STATE_RM_CUSHIONED =   2; //Trampoline
+float STATE_RM_BOUNCING  =   4; //Trampoline
+float STATE_RM_CLIMBING  =  16; //Wiremesh
+float STATE_RM_AIMING    =  32; //Lightpanel
+float STATE_RM_UNAIMING  =  64; //Lightpanel
+float STATE_RM_HOOKING   = 128; //Lightpanel
+float STATE_RM_UNHOOKING = 256; //Lightpanel
 
 .float prevstate;
 
@@ -1111,8 +1114,6 @@ void(entity client, float density, vector color) csf_set;
 .string hooknoise5;
 
 .float anchored;
-.entity nexthook;
-.float prepared;
 
 //Inky 20221029 Visited maps handling
 .float visitflag;

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -1662,7 +1662,7 @@ Player can move freely inside of this entity's volume, on walls and ceilings."
 	noise4(string) : "Sound file for a 'climbing' sound (if set, overrides 'sounds') Plays randomly alongside noise, noise2, and noise3."
 ]
 
-@SolidClass base(Appearflags, Targetname) = func_hook : "A lighthook panel; a player that is looking directly at the surface of this can latch onto it with the lighthook (default RMB)"
+@SolidClass base(Appearflags, Targetname, Target) = func_hook : "A lighthook panel; a player that is looking directly at the surface of this can latch onto it with the lighthook (default RMB)"
 [
 	speed(string) : "Speed at which the lighthook pulls the player (not the hook itself, which is infinitely fast); default 500." : "500"
 	

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -1690,6 +1690,11 @@ Player can move freely inside of this entity's volume, on walls and ceilings."
 	noise5(string) : "Sound file for the 'disable' sound."
 	
 	mdl(string) : "Model file for the tracer."
+	
+	spawnflags(Flags) =
+	[
+		1 : "Aim only" : 0
+	]
 ]
 
 @SolidClass base(Appearflags, Targetname) = trigger_monsterface : "Running monsters that do not see their target and touch this will face in the direction of the trigger's angle instead of the unseen target. Use this trigger to make monsters leave their sniping spot and execute complex maneuvers."

--- a/lighthook.qc
+++ b/lighthook.qc
@@ -51,9 +51,6 @@ void() GrappleReset =
 
 	if (self.enemy) {
 		self.enemy.anchored = 0;
-		if (self.enemy.nexthook) {
-			self.enemy.nexthook.prepared = 0;
-		}
 		if (self.enemy.locked_on) {
 			self.enemy.locked_on = 0;
 		}
@@ -75,7 +72,21 @@ void() GrappleReset =
 			}
 	}
 	
+	//Fire lightpanel targets on unhooking
+	if(self.owner.state & STATE_RM_HOOKING)
+	{
+		self.owner.state = self.owner.state - (self.owner.state & STATE_RM_HOOKING);
+		self.owner.state |= STATE_RM_UNHOOKING;
+		activator = self.owner;
+		entity oself = self;
+		self = self.owner.rotatecontroller;
+		SUB_UseTargets();
+		self = oself;
+		self.owner.state = self.owner.state - (self.owner.state & STATE_RM_UNHOOKING);
+	}
+	
 	remove(self);
+
 };
 
 void() GrappleTrack =


### PR DESCRIPTION
Lightpanel now able to fire targets upon
- Aiming
- De-aiming
- Hooking
- De-hooking

Also removed unused global fields .nexthook & .prepared.

Also added the diverted "Aim only" sub-feature. Allows a mapper to use a lightpanel as something able to trigger things when the player looks at it and/or away from it. Similar but not identical to progs_dump's trigger_look.