### PR TITLE
Lava ogre may not drop a backpack upon death

### DIFF
--- a/ogre.qc
+++ b/ogre.qc
@@ -1141,6 +1141,10 @@ void()	ogre_die3	=[	$death3,	ogre_die4	]
 		{
 			self.ammo_rockets = 2;
 		}
+		if (self.style == 4) // lavaball ogre jaycie erysdren 2021-09-14
+		{
+			self.ammo_rockets = 2;
+		}
 		else if (self.style == 0) //default Ogre
 		{
 			self.ammo_rockets = 2;


### PR DESCRIPTION
That's a bug reported in progs_dump 3.0 we inherited in Re:Mobilize.

See dumptruck_ds' description here:
https://github.com/dumptruckDS/progs_dump_qc/issues/195