### PR TITLE
Misc_modeltrain rotation + targets + counter print all

### DIFF
--- a/client.qc
+++ b/client.qc
@@ -99,7 +99,7 @@ void() DecodeLevelParms =
 	{
 		//Identify all the trigger_changelevel entities and give them a unique visitflag id.
 		float num, fv;
-		entity portal,marker;
+		entity portal;
 		
 		entity oself = self;
 		
@@ -871,7 +871,7 @@ void() CheckGrapple =
 		new.nextthink = time + 0.02;
 		
 		//Fire lightpanel targets on entering aiming mode
-		if(!self.state & STATE_RM_AIMING)
+		if(!(self.state & STATE_RM_AIMING))
 		{
 			self.state |= STATE_RM_AIMING;
 			self.rotatecontroller = trace_ent; //The .rotatecontroller property is reused in the lightpanel context to keep trace of what lightpanel was aimed at upon exiting aiming state (see if case below)
@@ -895,11 +895,11 @@ void() CheckGrapple =
 		self.state = self.state - (self.state & STATE_RM_UNAIMING);
 	}
 	
-	if (self.impulse==24 && !self.hook_out && !trace_ent.spawnflags & /*Aim only*/1) {
+	if (self.impulse==24 && !self.hook_out && !(trace_ent.spawnflags & /*Aim only*/1)) {
 		W_FireGrapple();
 		
 		//Fire lightpanel targets on hooking
-		if(self.state & STATE_RM_AIMING && (!self.state & STATE_RM_HOOKING))
+		if((self.state & STATE_RM_AIMING) && !(self.state & STATE_RM_HOOKING))
 		{
 			self.state = self.state - (self.state & STATE_RM_AIMING);
 			self.state |= STATE_RM_HOOKING;

--- a/cutscene.qc
+++ b/cutscene.qc
@@ -43,6 +43,7 @@ local   entity  s;
     s.effects       = o.effects;
     s.items         = o.items;
     s.enemy         = o.enemy;      // PM:  o.enemy changed to camera later.
+	s.fade_amt      = cvar("crosshair");
 
 // Save powerups
 // Pentagram
@@ -161,6 +162,7 @@ local   string  val;
     c.effects       = t.effects;
     c.items         = t.items;
     c.enemy         = t.enemy;      // PM:  Restore client's original enemy.
+	cvar_set("crosshair", ftos(t.fade_amt));
 
 // Restore powerups
     if (t.invincible_finished)
@@ -425,6 +427,7 @@ local   vector  looky;
     self.effects     = 0;
     self.items       = 0;
     self.weaponmodel = "";      // Remove weapon from the screen.
+	cvar_set("crosshair", "0");
 //- - - - - - - - - - - - - - - - - - -
 //    if (vision)
 //    {

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -2553,7 +2553,10 @@ If needed, the ammo values are cut off to always stay in the legal [0..100] rang
 ]
 @PointClass base(Appearflags, Target, Targetname) = trigger_counter : "Trigger: Counter"
 [
-	spawnflags(flags) = [ 1: "No Message" : 0 ]
+	spawnflags(flags) = [
+		1: "No Message" : 0
+		1048576 : "Message all players" : 0
+	]
 	count(integer) : "Count before trigger" : 2
 	delay (integer) : "Delay"
 	message(string) : "Message"

--- a/intermission.qc
+++ b/intermission.qc
@@ -342,6 +342,7 @@ float flag_value(float d) //Inky 20221025 Used for trigger_serverflags
 		case 22: return 2097152; break;
 		case 23: return 4194304; break;
 		case 24: return 8388608; break;
+		default: return 0;
 	}
 }
 

--- a/lighthook.qc
+++ b/lighthook.qc
@@ -353,7 +353,7 @@ void () W_FireGrapple =
 // called each frame by CLIENT.QC if client has hook_out
 void() GrappleService =
 {
-	local   vector  o, dist, vel;
+	local   vector  dist, vel;
 	local	float	v;
 
 	if (!self.on_hook) {

--- a/misc.qc
+++ b/misc.qc
@@ -1831,7 +1831,7 @@ void(entity tgt) target_textstory_spawn_helper = {
 
 void() target_textstory_use = {
 
-	if (!(activator.flags & FL_CLIENT)) return;
+	if (!(activator.flags & FL_CLIENT || self.spawnflags & TRIGGER_CENTERPRINTALL)) return;
 	if (self.estate != STATE_ACTIVE) return;
 
 	entity t;

--- a/plats.qc
+++ b/plats.qc
@@ -374,13 +374,28 @@ void() train_next = {
 
 	if (self.classname == "misc_modeltrain") {
 		if (!(self.spawnflags & TRAIN_NOROTATE)) {
-			destang = vectoangles(targ.origin - self.origin);
-			if (self.spawnflags & TRAIN_ROTATEY) {
-				destang_x = self.angles_x;
-				destang_z = self.angles_z;
+			void() angleMoveDone = SUB_Null;
+			
+			if (targ.origin == self.origin) angleMoveDone = train_wait;
+			
+			if(targ.angles)
+				destang = targ.angles;
+			else if (targ.origin != self.origin)
+				destang = vectoangles(targ.origin - self.origin);
+			else
+				destang = '0 0 0';
+			
+			if(destang != '0 0 0')
+			{
+				if (self.spawnflags & TRAIN_ROTATEY) {
+					destang_x = self.angles_x;
+					destang_z = self.angles_z;
+				}
+				if (self.multiplier > 0)
+					SUB_CalcAngleMoveController(destang, self.speed2*self.multiplier, self.rotatecontroller, targ, angleMoveDone);
+				else
+					self.angles = destang;
 			}
-			if (self.multiplier > 0) SUB_CalcAngleMoveController(destang, self.speed2*self.multiplier, SUB_Null, self.rotatecontroller);
-			else self.angles = destang;
 		}
 	}
 
@@ -389,6 +404,10 @@ void() train_next = {
 		if (self.classname == "misc_modeltrain" && self.style != TRAIN_STYLE_SINGLEANIM)
 			SUB_CallAsSelf(self.animcontroller.think, self.animcontroller);
 	}
+	
+	if (targ.origin == self.origin) //Rotation done, no translation
+		return;
+	
 	// if the TRAIN_CUSTOMALIGN flag is checked then the train should align
 	// with its path_corners based on the location of an "origin" brush added
 	// to the train by the mapper instead of the mins corner

--- a/plats.qc
+++ b/plats.qc
@@ -392,7 +392,7 @@ void() train_next = {
 					destang_z = self.angles_z;
 				}
 				if (self.multiplier > 0)
-					SUB_CalcAngleMoveController(destang, self.speed2*self.multiplier, self.rotatecontroller, targ, angleMoveDone);
+					SUB_CalcAngleMoveController(destang, self.speed2*self.multiplier, angleMoveDone, self.rotatecontroller);
 				else
 					self.angles = destang;
 			}

--- a/rm_mechanics.qc
+++ b/rm_mechanics.qc
@@ -131,7 +131,7 @@ void() wiremesh_touch =
 	other.wiremesh = self;
 	
 	//Fire wiremesh targets on climbing mode change
-	if(!other.state & STATE_RM_CLIMBING && !other.flags & FL_ONGROUND)
+	if(!(other.state & STATE_RM_CLIMBING) && !(other.flags & FL_ONGROUND))
 	{
 		other.state |= STATE_RM_CLIMBING;
 		activator = other;

--- a/subs.qc
+++ b/subs.qc
@@ -225,7 +225,7 @@ to not lose track of current think functions.
 */
 void() SUB_CalcAngleMoveDoneController;
 
-void(vector destangle, float tspeed, void() func, entity controller) SUB_CalcAngleMoveController =
+void(vector destangle, float tspeed, entity controller, entity path_corner, void() func) SUB_CalcAngleMoveController =
 {
 	local vector	destdelta;
 	local float		len, traveltime;
@@ -254,7 +254,8 @@ void(vector destangle, float tspeed, void() func, entity controller) SUB_CalcAng
 	self.avelocity = destdelta * (1 / traveltime);
 	
 	// Makes sure controller.owner points to self so it can be referenced later in the think function
-	controller.owner = self;  
+	controller.owner = self;
+	controller.enemy = path_corner;
 	controller.think1 = func;
 	controller.finalangle = destangle;
 	controller.think = SUB_CalcAngleMoveDoneController;
@@ -270,6 +271,9 @@ void() SUB_CalcAngleMoveDoneController =
 	self.owner.angles = self.finalangle;
 	self.owner.avelocity = '0 0 0';
 	self.nextthink = -1;
+	
+	SUB_UseEntTargets(self.enemy);
+	
 	if (self.think1)
 		SUB_CallAsSelf(self.think1, self.owner);
 };

--- a/subs.qc
+++ b/subs.qc
@@ -225,7 +225,7 @@ to not lose track of current think functions.
 */
 void() SUB_CalcAngleMoveDoneController;
 
-void(vector destangle, float tspeed, entity controller, entity path_corner, void() func) SUB_CalcAngleMoveController =
+void(vector destangle, float tspeed, void() func, entity controller) SUB_CalcAngleMoveController =
 {
 	local vector	destdelta;
 	local float		len, traveltime;
@@ -255,7 +255,6 @@ void(vector destangle, float tspeed, entity controller, entity path_corner, void
 	
 	// Makes sure controller.owner points to self so it can be referenced later in the think function
 	controller.owner = self;
-	controller.enemy = path_corner;
 	controller.think1 = func;
 	controller.finalangle = destangle;
 	controller.think = SUB_CalcAngleMoveDoneController;
@@ -271,8 +270,6 @@ void() SUB_CalcAngleMoveDoneController =
 	self.owner.angles = self.finalangle;
 	self.owner.avelocity = '0 0 0';
 	self.nextthink = -1;
-	
-	SUB_UseEntTargets(self.enemy);
 	
 	if (self.think1)
 		SUB_CallAsSelf(self.think1, self.owner);

--- a/triggers.qc
+++ b/triggers.qc
@@ -272,26 +272,32 @@ void() counter_use =
 	if (self.count < 0)
 		return;
 
+	/**/
+	entity msgEnt = world;
+	if (activator.classname == "player" && (self.spawnflags & SPAWNFLAG_NOMESSAGE) == 0)
+		msgEnt = activator;
+	else if (self.spawnflags & TRIGGER_CENTERPRINTALL)
+		msgEnt = find(world, classname, "player"); //Re:Mobilize is for many reasons singleplayer-focused, so let's not bother with a loop to find "all the players". Here the spawnflags simply means "send a message to player never mind they're the direct activator or not".
+	/**/
+	
 	if (self.count != 0)
 	{
-		if (activator.classname == "player"
-		&& (self.spawnflags & SPAWNFLAG_NOMESSAGE) == 0)
+		if (msgEnt)
 		{
 			if (self.count >= 4)
-				centerprint (activator, "There are more to go...");
+				centerprint (msgEnt, "There are more to go...");
 			else if (self.count == 3)
-				centerprint (activator, "Only 3 more to go...");
+				centerprint (msgEnt, "Only 3 more to go...");
 			else if (self.count == 2)
-				centerprint (activator, "Only 2 more to go...");
+				centerprint (msgEnt, "Only 2 more to go...");
 			else
-				centerprint (activator, "Only 1 more to go...");
+				centerprint (msgEnt, "Only 1 more to go...");
 		}
 		return;
 	}
 
-	if (activator.classname == "player"
-	&& (self.spawnflags & SPAWNFLAG_NOMESSAGE) == 0)
-		centerprint(activator, "Sequence completed!");
+	if (msgEnt)
+		centerprint(msgEnt, "Sequence completed!");
 	self.enemy = activator;
 	multi_trigger ();
 };

--- a/triggers.qc
+++ b/triggers.qc
@@ -273,8 +273,10 @@ void() counter_use =
 		return;
 
 	/**/
-	entity msgEnt = world;
-	if (activator.classname == "player" && (self.spawnflags & SPAWNFLAG_NOMESSAGE) == 0)
+	entity msgEnt;
+	if (self.spawnflags & SPAWNFLAG_NOMESSAGE)
+		msgEnt = world;
+	if (activator.classname == "player")
 		msgEnt = activator;
 	else if (self.spawnflags & TRIGGER_CENTERPRINTALL)
 		msgEnt = find(world, classname, "player"); //Re:Mobilize is for many reasons singleplayer-focused, so let's not bother with a loop to find "all the players". Here the spawnflags simply means "send a message to player never mind they're the direct activator or not".


### PR DESCRIPTION
Misc_modeltrain's rotation was an automatic calculation performed during a translation so that the model always faces the next path_corner. So it was meant as a side-effect of a translation over which the mapper had no control.
Now misc_modeltrain is able to perform pure rotations around its origin (with no translation involved) following mapper's need by setting the destination path_corner's .angles property.
Path_corner's targets are also taken into account with pure rotations.

As a side note, trigger_counter & target_textstory now supporting spawnflag TRIGGER_CENTERPRINTALL like regular triggers.