### PR TITLE
Aim-only hook events

### DIFF
--- a/client.qc
+++ b/client.qc
@@ -816,6 +816,7 @@ void() CheckWaterJump =
 	}
 };
 
+void(entity player) NotifyUnhook;
 void() CheckGrapple =
 {
 	
@@ -895,9 +896,11 @@ void() CheckGrapple =
 		self.state = self.state - (self.state & STATE_RM_UNAIMING);
 	}
 	
-	if (self.impulse==24 && !self.hook_out && !trace_ent.spawnflags & /*Aim only*/1) {
-		W_FireGrapple();
-		
+	if (self.impulse==24 && !self.hook_out && trace_ent.classname=="func_hook")
+	{
+		if(!(trace_ent.spawnflags & /*Aim only*/1))
+			W_FireGrapple();
+			
 		//Fire lightpanel targets on hooking
 		if(self.state & STATE_RM_AIMING && (!self.state & STATE_RM_HOOKING))
 		{
@@ -910,7 +913,6 @@ void() CheckGrapple =
 			self = oself;
 		}
 	}
-
 }
 
 
@@ -1175,10 +1177,17 @@ else
 	
 	// Re:Mobilize: Lighthook
 	
+	if (self.impulse==25)
+	{
+		if(self.rotatecontroller==world || (self.rotatecontroller!=world && self.rotatecontroller.spawnflags & /*Aim only*/1))
+			NotifyUnhook(self);
+	}
+	
 	CheckGrapple();
 	
 	if (self.hook_out)
 		GrappleService();
+		
 };
 
 /*

--- a/lighthook.qc
+++ b/lighthook.qc
@@ -46,6 +46,21 @@ void(entity h, entity player) GrappleTrail =
 	
 };
 
+void(entity player) NotifyUnhook =
+{
+	if(player.state & STATE_RM_HOOKING)
+	{
+		player.state = player.state - (player.state & STATE_RM_HOOKING);
+		player.state |= STATE_RM_UNHOOKING;
+		activator = player;
+		entity oself = self;
+		self = player.rotatecontroller;
+		SUB_UseTargets();
+		self = oself;
+		player.state = player.state - (player.state & STATE_RM_UNHOOKING);
+	}
+};
+
 void() GrappleReset =
 {
 
@@ -73,17 +88,7 @@ void() GrappleReset =
 	}
 	
 	//Fire lightpanel targets on unhooking
-	if(self.owner.state & STATE_RM_HOOKING)
-	{
-		self.owner.state = self.owner.state - (self.owner.state & STATE_RM_HOOKING);
-		self.owner.state |= STATE_RM_UNHOOKING;
-		activator = self.owner;
-		entity oself = self;
-		self = self.owner.rotatecontroller;
-		SUB_UseTargets();
-		self = oself;
-		self.owner.state = self.owner.state - (self.owner.state & STATE_RM_UNHOOKING);
-	}
+	NotifyUnhook(self.owner);
 	
 	remove(self);
 


### PR DESCRIPTION
Previously aim-only lightpanels simply ignored the HOOK key events.
Now, while still not triggering the grapple mechanics, they are able to detect the HOOK key events and to react to them if needed (by means of trigger_filter to fire targets).