### PR TITLE
trigger_changeskin

### DIFF
--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -3629,3 +3629,20 @@ Example: 3 targets of impulse respectively 3, 2 and 1 --> Total cumulated impuls
 		1 : "Consume" : 0
 	]
 ]
+
+@PointClass color(181 132 93) base(Appearflags, Targetname) = trigger_changeskin : "Changes the skin field on an entity.
+
+'skin' is the value of the new skin.
+
+'target' can be set to any targetname like usual but can also take the special value 'activator' or 'other'.
+'activator' is suited in conjunction with trigger_filter (eg to filter a monster's health level and change its skin to a damaged version below a certain amount).
+'other' is suited when trigger_changeskin is directly targeted by a monster to adopt a 'death skin' upon death.
+"
+[
+    skin(integer) : "The new skin value"
+	target(choices) : "The entity to change" =
+	[
+		"activator" : "activator"
+		"other" : "other"
+	]
+]

--- a/triggers.qc
+++ b/triggers.qc
@@ -1961,3 +1961,45 @@ void trigger_random ()
 	self.model="trigger_random by Inky";
 	self.use = trigger_random_use;
 }
+
+/*QUAKED trigger_changeskin (.5 .5 .5) ?
+Changes an entity's skin field
+
+target = entity to change (can be activator or other)
+skin = new value for skin field
+
+*/
+
+void() trigger_changeskin_use =
+{
+	if (self.estate != STATE_ACTIVE) return;
+
+	if(self.target == "activator")
+	{
+		activator.skin = self.skin;
+	}
+	else if(self.target == "other")
+	{
+		other.skin = self.skin;
+	}
+	else if (self.target)
+	{
+		for (entity e = world; (e = find(e, targetname, self.target)); )
+			e.skin = self.skin;
+		for (entity e = world; (e = find(e, targetname2, self.target)); )
+			e.skin = self.skin;
+		for (entity e = world; (e = find(e, targetname3, self.target)); )
+			e.skin = self.skin;
+		for (entity e = world; (e = find(e, targetname4, self.target)); )
+			e.skin = self.skin;
+	}
+
+};
+
+void() trigger_changeskin =
+{
+    if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+        return;
+
+    self.use = trigger_changeskin_use;
+};


### PR DESCRIPTION
New trigger to change its target's skin.
Can notably be used for monsters to feature a damaged skin below a certain amount of health or to indicate  boss phases.
Can also be used for monsters to feature a specific skin once dead.
(All that without having to change the monsters code/behavior)
Etc.