### PR TITLE
Remove useless/counterproductive 32 forward aiming offset

### DIFF
--- a/client.qc
+++ b/client.qc
@@ -825,13 +825,11 @@ void() CheckGrapple =
 	
 	// (Credit to Inky for this)
 	if (dummy) {
-		traceline((player_offset + (v_forward * 32)), (player_offset + (v_forward * 10000)), FALSE, dummy);
+		traceline(player_offset, (player_offset + (v_forward * 10000)), FALSE, dummy);
 	}
 	else {
-		traceline((player_offset + (v_forward * 32)), (player_offset + (v_forward * 10000)), FALSE, self);
+		traceline(player_offset, (player_offset + (v_forward * 10000)), FALSE, self);
 	}
-	
-	//traceline((player_offset + (v_forward * 32)), (player_offset + (v_forward * 10000)), FALSE, dummy);
 	
 	local	entity new, oself;
 	local	float dist;

--- a/client.qc
+++ b/client.qc
@@ -821,7 +821,9 @@ void() CheckGrapple =
 	player_offset = self.origin + self.view_ofs;
 	
 	// (Credit to Inky for this)
+	self.solid = SOLID_NOT;
 	traceline(player_offset, (player_offset + (v_forward * 10000)), FALSE, aimIgnore);
+	self.solid = SOLID_SLIDEBOX;
 	
 	local	entity new, oself;
 	local	float dist;

--- a/client.qc
+++ b/client.qc
@@ -11,9 +11,6 @@ void (vector org, entity death_owner) spawn_tdeath;
 float	modelindex_eyes, modelindex_player;
 void() SUB_CheckWaiting; // in triggers.qc
 
-entity dummy;
-
-
 void() SetChangeParms =
 {
 	if (self.health <= 0)
@@ -824,12 +821,7 @@ void() CheckGrapple =
 	player_offset = self.origin + self.view_ofs;
 	
 	// (Credit to Inky for this)
-	if (dummy) {
-		traceline(player_offset, (player_offset + (v_forward * 10000)), FALSE, dummy);
-	}
-	else {
-		traceline(player_offset, (player_offset + (v_forward * 10000)), FALSE, self);
-	}
+	traceline(player_offset, (player_offset + (v_forward * 10000)), FALSE, aimIgnore);
 	
 	local	entity new, oself;
 	local	float dist;

--- a/lighthook.qc
+++ b/lighthook.qc
@@ -252,12 +252,7 @@ void () W_FireGrapple =
 
 	makevectors(self.v_angle);
 	
-	if (self.volume) {
-		traceline(player_offset, (player_offset + (v_forward * 100000)), FALSE, dummy);
-	}
-	else {
-		traceline(player_offset, (player_offset + (v_forward * 100000)), FALSE, self);
-	}
+	traceline(player_offset, (player_offset + (v_forward * 100000)), FALSE, aimIgnore);
 	
 	if (!(trace_ent.classname=="func_hook") || trace_ent.estate == STATE_INACTIVE) {
 		return;

--- a/lighthook.qc
+++ b/lighthook.qc
@@ -252,7 +252,9 @@ void () W_FireGrapple =
 
 	makevectors(self.v_angle);
 	
+	self.solid = SOLID_NOT;
 	traceline(player_offset, (player_offset + (v_forward * 100000)), FALSE, aimIgnore);
+	self.solid = SOLID_SLIDEBOX;
 	
 	if (!(trace_ent.classname=="func_hook") || trace_ent.estate == STATE_INACTIVE) {
 		return;

--- a/lighthook.qc
+++ b/lighthook.qc
@@ -253,7 +253,7 @@ void () W_FireGrapple =
 	makevectors(self.v_angle);
 	
 	if (self.volume) {
-		traceline((player_offset + (v_forward * 32)), (player_offset + (v_forward * 100000)), FALSE, dummy);
+		traceline(player_offset, (player_offset + (v_forward * 100000)), FALSE, dummy);
 	}
 	else {
 		traceline(player_offset, (player_offset + (v_forward * 100000)), FALSE, self);

--- a/rm_mechanics.qc
+++ b/rm_mechanics.qc
@@ -269,7 +269,7 @@ void() func_hook =
 	}
 	
 	// Dummy spawn for nonsolid hookpanels
-	if (self.volume) {
+	if (self.volume && dummy==world) {
 		dummy = spawn();
 		dummy.solid = SOLID_NOT;
 	}

--- a/rm_mechanics.qc
+++ b/rm_mechanics.qc
@@ -268,12 +268,6 @@ void() func_hook =
 		self.frame = 1;
 	}
 	
-	// Dummy spawn for nonsolid hookpanels
-	if (self.volume && dummy==world) {
-		dummy = spawn();
-		dummy.solid = SOLID_NOT;
-	}
-	
 	// medieval sounds
 	if (self.sounds == 1) 
 	{

--- a/weapons.qc
+++ b/weapons.qc
@@ -412,12 +412,8 @@ void(float shotcount, vector dir, vector spread) FireBullets =
 		direction = dir + crandom()*spread_x*v_right + crandom()*spread_y*v_up;
 
 		// Hacky way to force SG/LG collision on nonsolid hookpanels
-		if ((self.state & STATE_RM_AIMING) && dummy) {
-			traceline (src, src + direction*2048, FALSE, dummy);
-		}
-		else {
-			traceline (src, src + direction*2048, FALSE, self);
-		}
+		traceline (src - 8*v_forward, src + direction*2048, FALSE, aimIgnore);
+		
 		if (trace_fraction != 1.0)
 			TraceAttack (4, direction);
 
@@ -794,12 +790,7 @@ void() W_FireLightning =
 	org = self.origin + '0 0 16';
 
 	// Hacky way to force SG/LG collision on nonsolid hookpanels
-	if ((self.state & STATE_RM_AIMING) && dummy) {
-		traceline (org, org + v_forward*600, TRUE, dummy);
-		}
-	else {
-		traceline (org, org + v_forward*600, TRUE, self);
-	}
+	traceline (org, org + v_forward*600, TRUE, aimIgnore);
 
 	WriteByte (MSG_BROADCAST, SVC_TEMPENTITY);
 	WriteByte (MSG_BROADCAST, TE_LIGHTNING2);

--- a/weapons.qc
+++ b/weapons.qc
@@ -413,7 +413,7 @@ void(float shotcount, vector dir, vector spread) FireBullets =
 
 		// Hacky way to force SG/LG collision on nonsolid hookpanels
 		if ((self.state & STATE_RM_AIMING) && dummy) {
-			traceline (src + v_forward*32, src + direction*2048, FALSE, dummy);
+			traceline (src, src + direction*2048, FALSE, dummy);
 		}
 		else {
 			traceline (src, src + direction*2048, FALSE, self);
@@ -795,7 +795,7 @@ void() W_FireLightning =
 
 	// Hacky way to force SG/LG collision on nonsolid hookpanels
 	if ((self.state & STATE_RM_AIMING) && dummy) {
-		traceline (org + v_forward*32, org + v_forward*600, TRUE, dummy);
+		traceline (org, org + v_forward*600, TRUE, dummy);
 		}
 	else {
 		traceline (org, org + v_forward*600, TRUE, self);

--- a/weapons.qc
+++ b/weapons.qc
@@ -412,7 +412,9 @@ void(float shotcount, vector dir, vector spread) FireBullets =
 		direction = dir + crandom()*spread_x*v_right + crandom()*spread_y*v_up;
 
 		// Hacky way to force SG/LG collision on nonsolid hookpanels
+		self.solid = SOLID_NOT;
 		traceline (src - 8*v_forward, src + direction*2048, FALSE, aimIgnore);
+		self.solid = SOLID_SLIDEBOX;
 		
 		if (trace_fraction != 1.0)
 			TraceAttack (4, direction);

--- a/weapons.qc
+++ b/weapons.qc
@@ -792,7 +792,9 @@ void() W_FireLightning =
 	org = self.origin + '0 0 16';
 
 	// Hacky way to force SG/LG collision on nonsolid hookpanels
+	self.solid = SOLID_NOT;
 	traceline (org, org + v_forward*600, TRUE, aimIgnore);
+	self.solid = SOLID_SLIDEBOX;
 
 	WriteByte (MSG_BROADCAST, SVC_TEMPENTITY);
 	WriteByte (MSG_BROADCAST, TE_LIGHTNING2);

--- a/world.qc
+++ b/world.qc
@@ -320,6 +320,8 @@ fog_color(string) : "Fog Color R/G/B example = (0.3 0.3 0.3)"
 sky(string) : "Sky Texture" :  : "Must have compatible skybox textures in gfx/env folder."
 */
 //=======================
+entity aimIgnore;
+
 void() worldspawn =
 {
 	DetectKnownRelease ();
@@ -327,6 +329,11 @@ void() worldspawn =
 	InitNewSpawnflags ();  // new spawnflags for all entities -- iw
 
 	lastspawn = world;
+	
+	// aimIgnore spawn
+	aimIgnore = spawn();
+	aimIgnore.solid = SOLID_NOT;
+	
 	InitBodyQue ();
 
 // custom map attributes


### PR DESCRIPTION
The offset of 32 units forward systematically applied when aiming at lightpanels not only ends up being useless under all circumstances, but also keeps Emerald's nice SG/LG trick from working when the player is really close from the non solid lightpanel surface, giving the player a way to exploit the inconsistency to cheat and shoot through the "force field".