### PR TITLE
'Player noclip' spawnflag on func_hook

### DIFF
--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -1699,6 +1699,7 @@ Player can move freely inside of this entity's volume, on walls and ceilings."
 	spawnflags(Flags) =
 	[
 		1 : "Aim only" : 0
+		2 : "Player noclip" : 0
 	]
 ]
 

--- a/rm_mechanics.qc
+++ b/rm_mechanics.qc
@@ -290,6 +290,9 @@ void() func_hook =
 	precache_sound ("misc/laseroff.wav");
 	self.use = func_hook_use;
 	
+	if (self.spawnflags & /*Player noclip*/2)
+		self.volume = 1;
+	
 	if (!self.speed) {
 		self.speed = 500;
 	}


### PR DESCRIPTION
This new spawnflag wraps the "pass-through lightpanel" feature as a spawnflag, which should arguably feel more familiar and natural to the mappers compared to the .volume property coming from nowhere.