### PR TITLE
Custom key used message

### DIFF
--- a/doors.qc
+++ b/doors.qc
@@ -296,7 +296,7 @@ void() door_touch =
 	if (!keylock_has_key_set ())
 		return;
 
-	keylock_try_to_unlock (other, "", door_unlock);
+	keylock_try_to_unlock (other, "", self.owner.message2, door_unlock);
 };
 
 

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -1856,6 +1856,7 @@ Originally unused in the game. Plays the sound of thunder at a random interval. 
 	lip(integer) : "Lip" : 8
 	dmg(integer) : "Damage inflicted when blocked" : 2
 	message(string) : "Message if touched"
+	message2(string) : "Message when key used"
 	health(integer) : "Health (shootable)" : 0
 	cnt(choices) : "Leave key in player's inventory?" : 0 =
 	[
@@ -1870,7 +1871,6 @@ Originally unused in the game. Plays the sound of thunder at a random interval. 
 	spawnflags(flags) =
 	[
 		1 : "Starts Open" : 0
-		2 : "Use key silently" : 0
 		4 : "Don't link" : 0
 		8 : "Gold Key required" : 0
 		16: "Silver Key required" : 0
@@ -2422,11 +2422,11 @@ NOTE: You must specify either the silver or gold key by setting the relevant spa
 	delay(float) : "Delay before trigger" : "0" : "Delay before trigger"
 	keyname(string) : "Sets the keyname of the item_key_custom which unlocks this entity. If any key spawnflag is selected (either silver or gold), this only changes the display name of the required key."
 	message(string) : "Custom message"
+	message2(string) : "Message when key used"
 	noise1(string) : "Sound file for the 'key required' sound (default is per worldtype)"
 	noise2(string) : "Sound file for the 'key used' sound (default is per worldtype)"
 	spawnflags(flags) =
 	[
-		2 : "Use key silently" : 0
 		8 : "Silver Key Required" : 0
 		16 : "Gold Key Required" : 0
 	]

--- a/hiptrig.qc
+++ b/hiptrig.qc
@@ -44,7 +44,7 @@ void() keytrigger_use =
 		return;
 
 	self.attack_finished = time + 2;
-	keylock_try_to_unlock (activator, self.message, keytrigger_unlock);
+	keylock_try_to_unlock (activator, self.message, self.message2, keytrigger_unlock);
 };
 
 void() keytrigger_touch =

--- a/keylock.qc
+++ b/keylock.qc
@@ -185,24 +185,22 @@ The self.cnt functionality is a feature of progs_dump and was not part
 of the original game.  -- iw
 ================
 */
-void(entity client, string custom_message,
+void(entity client, string failure_message, string success_message,
 		void() success_func) keylock_try_to_unlock =
 {
-	local string s;
+	local string s = "";
 
 // support for item_key_custom -- iw
 	if (!HasKeys (client, self.items, self.customkeys))
 	{
-		if (custom_message != "")
-			centerprint (client, custom_message);
+		if (failure_message != "")
+			centerprint (client, failure_message);
 		else
 			centerprint2 (client, "You need the ", self.netname);
 		sound (self, CHAN_VOICE, self.noise3, 1, ATTN_NORM);
 		return;
 	}
 
-// the old code in door_touch included a comment from dumptruck_ds
-// thanking RennyC re self.cnt
 	if (self.cnt)
 	{
 		s = "You used (and kept) the ";
@@ -214,14 +212,19 @@ void(entity client, string custom_message,
 		s = "You used the ";
 	}
 
-	if(!(self.spawnflags&/*Use key silently*/2))
+	if (success_message != "")
+	{
+		sprint (client, success_message);
+		sprint (client, "\n");
+	}
+	else
 	{
 		sprint (client, s);
 		sprint (client, self.netname);
 		sprint (client, "\n");
-
-		sound (self, CHAN_ITEM, self.noise4, 1, ATTN_NORM);
 	}
+
+	sound (self, CHAN_ITEM, self.noise4, 1, ATTN_NORM);
 	
 	success_func ();
 };


### PR DESCRIPTION
Removed the questionable 'Use key silently' spawnflag on func_door and trigger_usekey in favor of more flexibility.
Both entities now support the message2 property instead to print out a custom message when the required key was used (or no visible message by setting the property to a space character).