### PR TITLE
Custom monster hitbox

### DIFF
--- a/boss.qc
+++ b/boss.qc
@@ -257,7 +257,7 @@ void() boss_awake =
 
 	body_model ("progs/boss.mdl");
 	// setmodel (self, "progs/boss.mdl"); //custom_mdl -- dumptruck_ds
-	setsize (self, '-128 -128 -24', '128 128 256');
+	resize('-128 -128 -24', '128 128 256');
 
 	if (skill == 0)
 		self.health = 1;

--- a/boss2.qc
+++ b/boss2.qc
@@ -412,7 +412,7 @@ void() boss2_awake =
 
 	body_model ("progs/boss.mdl");
 	// setmodel (self, "progs/boss.mdl");
-	setsize (self, '-128 -128 -24', '128 128 256');
+	resize('-128 -128 -24', '128 128 256');
 
 	if (!self.health)
 	{

--- a/demon.qc
+++ b/demon.qc
@@ -298,7 +298,7 @@ void() monster_demon1 =
 	body_model ("progs/demon.mdl");
 	// setmodel (self, "progs/demon.mdl");
 
-	setsize (self, VEC_HULL2_MIN, VEC_HULL2_MAX);
+	resize(VEC_HULL2_MIN, VEC_HULL2_MAX);
 
   if (!self.health) //thanks RennyC -- dumptruck_ds
 	self.health = 300;
@@ -493,7 +493,7 @@ void() monster_dead_demon =
         if (self.spawnflags & 1)
 	{
 		self.solid = SOLID_BBOX;
-    setsize(self,'-43.63 -47.26 -50.53','32.48 24.65 30');
+		resize('-43.63 -47.26 -50.53','32.48 24.65 30');
 	}
 	else
 	{

--- a/dog.qc
+++ b/dog.qc
@@ -457,7 +457,7 @@ void() monster_dog =
 	body_model ("progs/dog.mdl"); //dumptruck_ds
 	// setmodel (self, "progs/dog.mdl");
 
-	setsize (self, '-32 -32 -24', '32 32 40');
+	resize('-32 -32 -24', '32 32 40');
 
 	if (!self.health) //thanks RennyC -- dumptruck_ds
 	self.health = 25;
@@ -494,7 +494,7 @@ void() monster_dead_dog =
         if (self.spawnflags & 1)
 	{
 		self.solid = SOLID_BBOX;
-                setsize(self,'-24.51 -16.5 -50.37','28.2 13.81 30');
+        resize('-24.51 -16.5 -50.37','28.2 13.81 30');
 	}
 	else
 	{

--- a/dtmisc.qc
+++ b/dtmisc.qc
@@ -531,7 +531,7 @@ void() gib_head_demon =
 	if (self.spawnflags & 1)
 	{
 		self.solid = SOLID_BBOX;
-               	setsize(self,'-13.64 -16.77 -0.11','17.44 16.22 30');
+        resize('-13.64 -16.77 -0.11','17.44 16.22 30');
 	}
 	else
 	{
@@ -556,7 +556,7 @@ void() gib_head_dog =
 	if (self.spawnflags & 1)
 	{
 		self.solid = SOLID_BBOX;
-               	setsize(self,'-9.66 -11.89 -0.2','6.57 7.96 13.29');
+        resize('-9.66 -11.89 -0.2','6.57 7.96 13.29');
 	}
 	else
 	{
@@ -581,7 +581,7 @@ void() gib_head_army =
 	if (self.spawnflags & 1)
 	{
 		self.solid = SOLID_BBOX;
-               	setsize(self,'-9.67 -8.27 -0.28','4.05 4.8 13.41');
+        resize('-9.67 -8.27 -0.28','4.05 4.8 13.41');
 	}
 	else
 	{
@@ -605,7 +605,7 @@ void() gib_head_hell_knight =
 	if (self.spawnflags & 1)
 	{
 		self.solid = SOLID_BBOX;
-               	setsize(self,'-7.9 -12.97 -0.63','10.55 8.87 21.06');
+        resize('-7.9 -12.97 -0.63','10.55 8.87 21.06');
 	}
 	else
 	{
@@ -629,7 +629,7 @@ void() gib_head_knight =
 	if (self.spawnflags & 1)
 	{
 		self.solid = SOLID_BBOX;
-               	setsize(self,'-8.17 -7.47 -0.13','8.36 6.5 30');
+        resize('-8.17 -7.47 -0.13','8.36 6.5 30');
 	}
 	else
 	{
@@ -654,7 +654,7 @@ void() gib_head_enforcer =
 	if (self.spawnflags & 1)
 	{
 		self.solid = SOLID_BBOX;
-               	setsize(self,'-10.63 -10.23 -0.05','9.27 8.25 30');
+        resize('-10.63 -10.23 -0.05','9.27 8.25 30');
 	}
 	else
 	{
@@ -678,7 +678,7 @@ void() gib_head_ogre =
 	if (self.spawnflags & 1)
 	{
 		self.solid = SOLID_BBOX;
-               	setsize(self,'-12.35 -15.7 -0.17','10.67 13.88 30');
+        resize('-12.35 -15.7 -0.17','10.67 13.88 30');
 	}
 	else
 	{
@@ -702,7 +702,7 @@ void() gib_head_player =
 	if (self.spawnflags & 1)
 	{
 		self.solid = SOLID_BBOX;
-               	setsize(self,'-9.67 -12.38 -2.1','11.49 50.7 30');
+        resize('-9.67 -12.38 -2.1','11.49 50.7 30');
 	}
 	else
 	{
@@ -726,7 +726,7 @@ void() gib_head_shalrath =
 	if (self.spawnflags & 1)
 	{
 		self.solid = SOLID_BBOX;
-               	setsize(self,'-19.85 -19.09 -1.44','13.72 16.8 30');
+        resize('-19.85 -19.09 -1.44','13.72 16.8 30');
 	}
 	else
 	{
@@ -750,7 +750,7 @@ void() gib_head_shambler =
 	if (self.spawnflags & 1)
 	{
 		self.solid = SOLID_BBOX;
-               	setsize(self,'-15.15 -20.638 -0.45','21.44 21.76 30');
+        resize('-15.15 -20.638 -0.45','21.44 21.76 30');
 	}
 	else
 	{
@@ -774,7 +774,7 @@ void() gib_head_wizard =
 	if (self.spawnflags & 1)
 	{
 		self.solid = SOLID_BBOX;
-               	setsize(self,'-10.41 -8.66 -0.54','6.52 10.82 30');
+        resize('-10.41 -8.66 -0.54','6.52 10.82 30');
 	}
 	else
 	{
@@ -798,7 +798,7 @@ void() gib_misc_1 =
 	if (self.spawnflags & 1)
 	{
 		self.solid = SOLID_BBOX;
-               	setsize(self,'-3.57 -8.06 -3.34','3.69 8.31 30');
+        resize('-3.57 -8.06 -3.34','3.69 8.31 30');
 	}
 	else
 	{
@@ -822,7 +822,7 @@ void() gib_misc_2 =
 	if (self.spawnflags & 1)
 	{
 		self.solid = SOLID_BBOX;
-               	setsize(self,'-12.68 -14.83 -6.19','13.53 14.57 30');
+        resize('-12.68 -14.83 -6.19','13.53 14.57 30');
 	}
 	else
 	{
@@ -846,7 +846,7 @@ void() gib_misc_3 =
 	if (self.spawnflags & 1)
 	{
 		self.solid = SOLID_BBOX;
-               	setsize(self,'-18.95 -15.92 -3.13','13.17 15.66 30');
+        resize('-18.95 -15.92 -3.13','13.17 15.66 30');
 	}
 	else
 	{

--- a/enforcer.qc
+++ b/enforcer.qc
@@ -948,7 +948,7 @@ void() monster_enforcer =
 	body_model ("progs/enforcer.mdl"); // SPIKE to the RESCUE!!!! - got this fixed. -- dumptruck_ds
 	// // setmodel (self, "progs/enforcer.mdl"); //orginal dumptruck_ds
 
-	setsize (self, '-16 -16 -24', '16 16 40');
+	resize('-16 -16 -24', '16 16 40');
 
 	if (!self.proj_speed_mod)
 	{
@@ -1021,7 +1021,7 @@ void() monster_dead_enforcer =
 		if (self.spawnflags & 1)
 		{
 			self.solid = SOLID_BBOX;
-                	setsize(self,'-41.16 -45.65 -51.95','21.45 25.49 30');
+            resize('-41.16 -45.65 -51.95','21.45 25.49 30');
 		}
 		else
 		{
@@ -1034,7 +1034,7 @@ void() monster_dead_enforcer =
 		if (self.spawnflags & 1)
 		{
 			self.solid = SOLID_BBOX;
-                	setsize(self,'-39.85 -29.35 -49.07','20.52 33.17 30');
+            resize('-39.85 -29.35 -49.07','20.52 33.17 30');
 		}
 		else
 		{

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -3664,8 +3664,6 @@ Example: 3 targets of impulse respectively 3, 2 and 1 --> Total cumulated impuls
 
 'killtarget' is the target killed upon entering the trigger.
 'killtarget2' is the target killed upon leaving the trigger.
-
-'spawnflags' is used to adjust who can fire the trigger.
 "
 [
 	target(target_destination) : "Target (fired upon entering the trigger)"

--- a/fish.qc
+++ b/fish.qc
@@ -286,7 +286,7 @@ void() monster_fish =
 	body_model ("progs/fish.mdl");
 	// setmodel (self, "progs/fish.mdl");
 
-	setsize (self, '-16 -16 -24', '16 16 24');
+	resize('-16 -16 -24', '16 16 24');
 
 	if (!self.health) //thanks RennyC -- dumptruck_ds
 	self.health = 25;

--- a/hknight.qc
+++ b/hknight.qc
@@ -116,7 +116,7 @@ void(float offset) hknight_shot =
 			newmis.skin = 0;
 		}
 	}
-	setsize(newmis, VEC_ORIGIN, VEC_ORIGIN);
+	setsize (newmis, VEC_ORIGIN, VEC_ORIGIN);
 	sound_attack (self, CHAN_WEAPON, "hknight/attack1.wav", 1, ATTN_NORM);
 };
 

--- a/hknight.qc
+++ b/hknight.qc
@@ -116,7 +116,7 @@ void(float offset) hknight_shot =
 			newmis.skin = 0;
 		}
 	}
-	resize(VEC_ORIGIN, VEC_ORIGIN);
+	setsize(newmis, VEC_ORIGIN, VEC_ORIGIN);
 	sound_attack (self, CHAN_WEAPON, "hknight/attack1.wav", 1, ATTN_NORM);
 };
 

--- a/hknight.qc
+++ b/hknight.qc
@@ -116,7 +116,7 @@ void(float offset) hknight_shot =
 			newmis.skin = 0;
 		}
 	}
-	setsize (newmis, VEC_ORIGIN, VEC_ORIGIN);
+	resize(VEC_ORIGIN, VEC_ORIGIN);
 	sound_attack (self, CHAN_WEAPON, "hknight/attack1.wav", 1, ATTN_NORM);
 };
 
@@ -671,7 +671,7 @@ void() monster_hell_knight =
 	body_model ("progs/hknight.mdl"); // custom_mdls dumptruck_ds
 	// setmodel (self, "progs/hknight.mdl");
 
-	setsize (self, '-16 -16 -24', '16 16 40');
+	resize('-16 -16 -24', '16 16 40');
 
 	if (!self.health) //thanks RennyC -- dumptruck_ds
 	self.health = 250;
@@ -732,7 +732,7 @@ void() monster_dead_hell_knight =
 		if (self.spawnflags & 1)
 		{
 			self.solid = SOLID_BBOX;
-                	setsize(self,'-68.96 -20.43 -53.98','34.8 21.15 30');
+            resize('-68.96 -20.43 -53.98','34.8 21.15 30');
 		}
 		else
 		{
@@ -745,7 +745,7 @@ void() monster_dead_hell_knight =
 		if (self.spawnflags & 1)
 		{
 			self.solid = SOLID_BBOX;
-                	setsize(self,'-42.05 -31.07 -51.56','46.34 25.02 30');
+            resize('-42.05 -31.07 -51.56','46.34 25.02 30');
 		}
 		else
 		{

--- a/items.qc
+++ b/items.qc
@@ -82,7 +82,7 @@ void() DelaySpawnItem =
 {
 	self.solid = SOLID_TRIGGER;
 	setmodel (self, self.mdl);
-	setsize (self, self.pos1, self.pos2);
+	resize(self.pos1, self.pos2);
 
 	if (!(self.spawnflags & ITEM_SPAWNSILENT)) 			// SILENT, gb
 		// sound (self, CHAN_VOICE, "items/itembk2.wav", 1, ATTN_NORM);
@@ -341,7 +341,7 @@ void() item_health =
 		if !(self.particles_offset)
 		self.particles_offset = '16 16 8'; // dumptruck_ds custom health models and sounds END
 	}
-	setsize (self, '0 0 0', '32 32 56');
+	resize('0 0 0', '32 32 56');
 	StartItem ();
 };
 
@@ -366,7 +366,7 @@ void() item_health_vial =
 
 	self.healamount = 5;
 	self.healtype = 2; // over heal and count down like mega health -- dumptruck_ds
-	setsize (self, '-16 -16 0', '16 16 56');
+	resize('-16 -16 0', '16 16 56');
 	if !(self.particles_offset)
 	self.particles_offset = '0 0 0';
 	StartItem ();
@@ -612,7 +612,7 @@ void() item_armor_shard =
 	precache_sound_misc ("dump/armsh1.wav");
 	if !(self.skin) // dumptruck_ds custom models and sounds END
 	self.skin = 0;
-	setsize (self, '-16 -16 0', '16 16 56');
+	resize('-16 -16 0', '16 16 56');
 	StartItem ();
 };
 
@@ -634,7 +634,7 @@ void() item_armor1 =
 	precache_sound_misc ("items/armor1.wav");
 	if !(self.skin) // dumptruck_ds custom models and sounds END
 	self.skin = 0;
-	setsize (self, '-16 -16 0', '16 16 56');
+	resize('-16 -16 0', '16 16 56');
 	StartItem ();
 };
 
@@ -660,7 +660,7 @@ void() item_armor2 =
 	if !(self.skin) // dumptruck_ds custom models and sounds END
 	self.skin = 1;
 	precache_sound_misc ("items/armor1.wav");
-	setsize (self, '-16 -16 0', '16 16 56');
+	resize('-16 -16 0', '16 16 56');
 	StartItem ();
 };
 
@@ -688,7 +688,7 @@ void() item_armorInv =
 	if !(self.skin) // dumptruck_ds custom models and sounds END
 	self.skin = 2;
 	precache_sound_misc ("items/armor1.wav");
-	setsize (self, '-16 -16 0', '16 16 56');
+	resize('-16 -16 0', '16 16 56');
 	StartItem ();
 };
 
@@ -923,7 +923,7 @@ void() weapon_axe =
 	self.weapon = IT_AXE;
 	self.netname = "Axe";
 	self.touch = weapon_touch;
-	setsize (self, '-16 -16 0', '16 16 56');
+	resize('-16 -16 0', '16 16 56');
 	StartItem ();
 };
 /*QUAKED weapon_shotgun (0 .5 .8) (-16 -16 0) (16 16 32) X STYLE_1 STYLE_2 X X SPAWN_SILENT TRIGGER_SPAWNED SUSPENDED_IN_AIR NOT_ON_EASY NOT_ON_NORMAL NOT_ON_HARD_OR_NIGHTMARE NOT_IN_DEATHMATCH NOT_IN_COOP NOT_IN_SINGLEPLAYER RESPAWN_WITH_DM_EFFECTS NOT_ON_HARD_ONLY NOT_ON_NIGHTMARE_ONLY
@@ -943,7 +943,7 @@ void() weapon_shotgun =
 	self.weapon = IT_SHOTGUN;
 	self.netname = "Shotgun";
 	self.touch = weapon_touch;
-	setsize (self, '-16 -16 0', '16 16 56');
+	resize('-16 -16 0', '16 16 56');
 	StartItem ();
 };
 // johnfitz
@@ -963,7 +963,7 @@ void() weapon_supershotgun =
 	self.weapon = IT_SUPER_SHOTGUN;
 	self.netname = "Double-barrelled Shotgun";
 	self.touch = weapon_touch;
-	setsize (self, '-16 -16 0', '16 16 56');
+	resize('-16 -16 0', '16 16 56');
 	self.particles_offset = '0 0 33';
 	StartItem ();
 };
@@ -983,7 +983,7 @@ void() weapon_nailgun =
 	self.weapon = IT_NAILGUN;
 	self.netname = "nailgun";
 	self.touch = weapon_touch;
-	setsize (self, '-16 -16 0', '16 16 56');
+	resize('-16 -16 0', '16 16 56');
 	self.particles_offset = '0 0 31';
 	StartItem ();
 };
@@ -1003,7 +1003,7 @@ void() weapon_supernailgun =
 	self.weapon = IT_SUPER_NAILGUN;
 	self.netname = "Super Nailgun";
 	self.touch = weapon_touch;
-	setsize (self, '-16 -16 0', '16 16 56');
+	resize('-16 -16 0', '16 16 56');
 	self.particles_offset = '0 0 34';
 	StartItem ();
 };
@@ -1023,7 +1023,7 @@ void() weapon_grenadelauncher =
 	self.weapon = 3;
 	self.netname = "Grenade Launcher";
 	self.touch = weapon_touch;
-	setsize (self, '-16 -16 0', '16 16 56');
+	resize('-16 -16 0', '16 16 56');
 	self.particles_offset = '0 0 28';
 	StartItem ();
 };
@@ -1043,7 +1043,7 @@ void() weapon_rocketlauncher =
 	self.weapon = 3;
 	self.netname = "Rocket Launcher";
 	self.touch = weapon_touch;
-	setsize (self, '-16 -16 0', '16 16 56');
+	resize('-16 -16 0', '16 16 56');
 	self.particles_offset = '0 0 32';
 	StartItem ();
 };
@@ -1064,7 +1064,7 @@ void() weapon_lightning =
 	self.weapon = 3;
 	self.netname = "Thunderbolt";
 	self.touch = weapon_touch;
-	setsize (self, '-16 -16 0', '16 16 56');
+	resize('-16 -16 0', '16 16 56');
 	self.particles_offset = '0 0 31';
 	StartItem ();
 };
@@ -1226,7 +1226,7 @@ void() item_shells =
 	}
 	self.weapon = 1;
 	self.netname = "shells";
-	setsize (self, '0 0 0', '32 32 56');
+	resize('0 0 0', '32 32 56');
 	StartItem ();
 };
 
@@ -1286,7 +1286,7 @@ void() item_spikes =
 	}
 	self.weapon = 2;
 	self.netname = "nails";
-	setsize (self, '0 0 0', '32 32 56');
+	resize('0 0 0', '32 32 56');
 	StartItem ();
 };
 
@@ -1343,7 +1343,7 @@ void() item_rockets =
 	}
 	self.weapon = 3;
 	self.netname = "rockets";
-	setsize (self, '0 0 0', '32 32 56');
+	resize('0 0 0', '32 32 56');
 	StartItem ();
 };
 
@@ -1403,7 +1403,7 @@ void() item_cells =
 	}
 	self.weapon = 4;
 	self.netname = "cells";
-	setsize (self, '0 0 0', '32 32 56');
+	resize('0 0 0', '32 32 56');
 	StartItem ();
 };
 
@@ -1601,7 +1601,7 @@ void() key_start =
 	key_setsounds ();
 	self.particles_offset = '0 0 18';
 	self.touch = key_touch;
-	setsize (self, '-16 -16 -24', '16 16 32');
+	resize('-16 -16 -24', '16 16 32');
 	StartItem ();
 };
 
@@ -1866,7 +1866,7 @@ void() item_sigil =
 	}
 
 	self.touch = sigil_touch;
-	setsize (self, '-16 -16 -24', '16 16 32');
+	resize('-16 -16 -24', '16 16 32');
 	self.particles_offset = '0 0 18';
 	StartItem ();
 };
@@ -1985,7 +1985,7 @@ void() item_artifact_invulnerability =
 	body_model ("progs/invulner.mdl");
 	self.netname = "Pentagram of Protection";
 	self.items = IT_INVULNERABILITY;
-	setsize (self, '-16 -16 -24', '16 16 32');
+	resize('-16 -16 -24', '16 16 32');
 	if !(self.particles_offset)  // t_fog fix for custom models dumptruck_ds
 	self.particles_offset = '0 0 16';
 	StartItem ();
@@ -2011,7 +2011,7 @@ void() item_artifact_envirosuit =
 	body_model ("progs/suit.mdl");
 	self.netname = "Biosuit";
 	self.items = IT_SUIT;
-	setsize (self, '-16 -16 -24', '16 16 32');
+	resize('-16 -16 -24', '16 16 32');
 	if !(self.particles_offset)  // t_fog fix for custom models dumptruck_ds
 	self.particles_offset = '0 0 32';
 	StartItem ();
@@ -2039,7 +2039,7 @@ void() item_artifact_invisibility =
 	body_model ("progs/invisibl.mdl");
 	self.netname = "Ring of Shadows";
 	self.items = IT_INVISIBILITY;
-	setsize (self, '-16 -16 -24', '16 16 32');
+	resize('-16 -16 -24', '16 16 32');
 	if !(self.particles_offset)  // t_fog fix for custom models dumptruck_ds
 	self.particles_offset = '0 0 0';
 	StartItem ();
@@ -2067,7 +2067,7 @@ void() item_artifact_super_damage =
 	if !(self.netname) // custom name -- dumptruck_ds
 	self.netname = "Quad Damage";
 	self.items = IT_QUAD;
-	setsize (self, '-16 -16 -24', '16 16 32');
+	resize('-16 -16 -24', '16 16 32');
 	if !(self.particles_offset)  // t_fog fix for custom models dumptruck_ds
 	self.particles_offset = '0 0 16';
 	StartItem ();
@@ -2239,7 +2239,7 @@ void() DropKey1 =
 	item.items = IT_KEY1;
 	item.solid = SOLID_TRIGGER;
 	item.movetype = MOVETYPE_TOSS;
-	setsize (item, '-16 -16 0', '16 16 56');
+	resize('-16 -16 0', '16 16 56');
 	item.touch = key_touch;
 };
 
@@ -2278,7 +2278,7 @@ void() DropKey2 =
 	item.items = IT_KEY2;
 	item.solid = SOLID_TRIGGER;
 	item.movetype = MOVETYPE_TOSS;
-	setsize (item, '-16 -16 0', '16 16 56');
+	resize('-16 -16 0', '16 16 56');
 	item.touch = key_touch;
 };
 
@@ -2296,7 +2296,7 @@ void() DropVial = //
 	setmodel(item, "progs/h_mdls/pd_vial.mdl");
 	item.solid = SOLID_TRIGGER;
 	item.movetype = MOVETYPE_TOSS;
-	setsize (item, '-16 -16 0', '16 16 56');
+	resize('-16 -16 0', '16 16 56');
 	item.touch = health_touch;
 	item.healamount = 5;
 	item.healtype = 0;
@@ -2319,7 +2319,7 @@ void() DropShard = //
 	setmodel(item, "progs/armshr.mdl");
 	item.solid = SOLID_TRIGGER;
 	item.movetype = MOVETYPE_TOSS;
-	setsize (item, '-16 -16 0', '16 16 56');
+	resize('-16 -16 0', '16 16 56');
 	item.touch = shard_touch;
 	item.snd_misc = "dump/armsh1.wav";
 
@@ -2430,7 +2430,7 @@ void() DropBackpack =
 	item.solid = SOLID_TRIGGER;
 	item.movetype = MOVETYPE_TOSS;
 	setmodel (item, "progs/backpack.mdl");
-	setsize (item, '-16 -16 0', '16 16 56');
+	resize('-16 -16 0', '16 16 56');
 	item.touch = BackpackTouch;
 
 	item.nextthink = time + 120;	// remove after 2 minutes
@@ -2568,6 +2568,6 @@ void() item_backpack =
 	precache_body_model ("progs/pd_bpack.mdl");
 	body_model ("progs/pd_bpack.mdl");
 	// setmodel (self, "progs/backpack.mdl");
-	setsize (self, '-16 -16 0', '16 16 56');
+	resize('-16 -16 0', '16 16 56');
 	StartItem ();
 };

--- a/items.qc
+++ b/items.qc
@@ -2239,7 +2239,7 @@ void() DropKey1 =
 	item.items = IT_KEY1;
 	item.solid = SOLID_TRIGGER;
 	item.movetype = MOVETYPE_TOSS;
-	resize('-16 -16 0', '16 16 56');
+	setsize (item, '-16 -16 0', '16 16 56');
 	item.touch = key_touch;
 };
 
@@ -2278,7 +2278,7 @@ void() DropKey2 =
 	item.items = IT_KEY2;
 	item.solid = SOLID_TRIGGER;
 	item.movetype = MOVETYPE_TOSS;
-	resize('-16 -16 0', '16 16 56');
+	setsize (item, '-16 -16 0', '16 16 56');
 	item.touch = key_touch;
 };
 
@@ -2296,7 +2296,7 @@ void() DropVial = //
 	setmodel(item, "progs/h_mdls/pd_vial.mdl");
 	item.solid = SOLID_TRIGGER;
 	item.movetype = MOVETYPE_TOSS;
-	resize('-16 -16 0', '16 16 56');
+	setsize (item, '-16 -16 0', '16 16 56');
 	item.touch = health_touch;
 	item.healamount = 5;
 	item.healtype = 0;
@@ -2319,7 +2319,7 @@ void() DropShard = //
 	setmodel(item, "progs/armshr.mdl");
 	item.solid = SOLID_TRIGGER;
 	item.movetype = MOVETYPE_TOSS;
-	resize('-16 -16 0', '16 16 56');
+	setsize (item, '-16 -16 0', '16 16 56');
 	item.touch = shard_touch;
 	item.snd_misc = "dump/armsh1.wav";
 
@@ -2430,7 +2430,7 @@ void() DropBackpack =
 	item.solid = SOLID_TRIGGER;
 	item.movetype = MOVETYPE_TOSS;
 	setmodel (item, "progs/backpack.mdl");
-	resize('-16 -16 0', '16 16 56');
+	setsize (item, '-16 -16 0', '16 16 56');
 	item.touch = BackpackTouch;
 
 	item.nextthink = time + 120;	// remove after 2 minutes

--- a/knight.qc
+++ b/knight.qc
@@ -356,7 +356,7 @@ void() monster_knight =
 	body_model ("progs/knight.mdl"); // dumptruck_ds custom_mdls
 	// setmodel (self, "progs/knight.mdl");
 
-	setsize (self, '-16 -16 -24', '16 16 40');
+	resize('-16 -16 -24', '16 16 40');
 
 	if (!self.health) //thanks RennyC -- dumptruck_ds
 	self.health = 75;
@@ -395,7 +395,7 @@ void() monster_dead_knight =
 		if (self.spawnflags & 1)
 		{
 			self.solid = SOLID_BBOX;
-                	setsize(self,'-25.56 -14.56 -50.49','26.45 40.2 30');
+            resize('-25.56 -14.56 -50.49','26.45 40.2 30');
 		}
 		else
 		{
@@ -408,7 +408,7 @@ void() monster_dead_knight =
 		if (self.spawnflags & 1)
 		{
 			self.solid = SOLID_BBOX;
-                	setsize(self,'-30.36 -45.6 -50.18','28.29 11.59 30');
+            resize('-30.36 -45.6 -50.18','28.29 11.59 30');
 		}
 		else
 		{

--- a/monsters.qc
+++ b/monsters.qc
@@ -516,3 +516,22 @@ void() swimmonster_start =
 	self.think = swimmonster_start_go;
 	total_monsters = total_monsters + 1;
 };
+
+void(vector defaultmin, vector defaultmax) resize =
+{
+	vector vmin = defaultmin, vmax = defaultmax;
+
+	if(self.mdlsz)
+	{
+		if(!self.centeroffset) self.centeroffset = '0 0 0';
+
+		vmin_x = self.centeroffset_x - (self.mdlsz_x / 2);
+		vmin_y = self.centeroffset_y - (self.mdlsz_y / 2);
+		vmin_z = self.centeroffset_z - (self.mdlsz_z / 2);
+
+		vmax_x = self.centeroffset_x + (self.mdlsz_x / 2);
+		vmax_y = self.centeroffset_y + (self.mdlsz_y / 2);
+		vmax_z = self.centeroffset_z + (self.mdlsz_z / 2);
+    }
+	setsize(self, vmin, vmax);
+};

--- a/ogre.qc
+++ b/ogre.qc
@@ -1367,7 +1367,7 @@ void() monster_ogre =
 	body_model ("progs/ogre.mdl");
 	// setmodel (self, "progs/ogre.mdl");
 
-	setsize (self, VEC_HULL2_MIN, VEC_HULL2_MAX);
+	resize(VEC_HULL2_MIN, VEC_HULL2_MAX);
 	if (!self.proj_speed_mod)
 	{
 		self.proj_speed_mod = 1;
@@ -1492,7 +1492,7 @@ void() monster_ogre_marksman =
 	body_model ("progs/ogre.mdl");
 	// setmodel (self, "progs/ogre.mdl");
 
-	setsize (self, VEC_HULL2_MIN, VEC_HULL2_MAX);
+	resize(VEC_HULL2_MIN, VEC_HULL2_MAX);
 	if (!self.proj_speed_mod)
 	{
 		self.proj_speed_mod = 1;
@@ -1550,7 +1550,7 @@ void() monster_dead_ogre =
 		if (self.spawnflags & 1)
 		{
 			self.solid = SOLID_BBOX;
-                	setsize(self,'-40.64 -54.06 -54.1','29.42 54.63 30');
+            resize('-40.64 -54.06 -54.1','29.42 54.63 30');
 		}
 		else
 		{
@@ -1563,7 +1563,7 @@ void() monster_dead_ogre =
 		if (self.spawnflags & 1)
 		{
 			self.solid = SOLID_BBOX;
-                	setsize(self,'-45.64 -29.46 -54.52','33.87 39.18 30');
+            resize('-45.64 -29.46 -54.52','33.87 39.18 30');
 		}
 		else
 		{

--- a/oldone.qc
+++ b/oldone.qc
@@ -281,7 +281,7 @@ void() monster_oldone =
 
 	body_model ("progs/oldone.mdl"); //custom_mdls dumptruck_ds
 	// setmodel (self, "progs/oldone.mdl");
-	setsize (self, '-160 -128 -24', '160 128 256');
+	resize('-160 -128 -24', '160 128 256');
 
 	self.health = 40000;		// kill by telefrag
 	self.think = old_idle1;

--- a/oldone2.qc
+++ b/oldone2.qc
@@ -344,7 +344,7 @@ void() monster_oldone2 =
 
 	body_model ("progs/oldone.mdl"); //custom_mdls dumptruck_ds
 	// setmodel (self, "progs/oldone.mdl");
-	setsize (self, '-160 -128 -24', '160 128 256');
+	resize('-160 -128 -24', '160 128 256');
 
 	if (!self.health)
 	{

--- a/plats.qc
+++ b/plats.qc
@@ -793,7 +793,7 @@ void() misc_teleporttrain =
 	else
 	body_model ("progs/teleport.mdl");
 	// precache_model ("progs/teleport.mdl");
-	setsize (self, '-16 -16 -16', '16 16 16');
+	resize('-16 -16 -16', '16 16 16');
 
 	//Causes the ball to spin around like it was originally intended to.
 	if (!(self.spawnflags & 2)) 			//don't spin - helpful for invisible spawner -- dumptruck_ds

--- a/player.qc
+++ b/player.qc
@@ -699,7 +699,7 @@ void() player_dead_axe =
 	if (self.spawnflags & 1)
 	{
 		self.solid = SOLID_BBOX;
-               	setsize(self,'-38.72 -5.83 -50.45','28.73 33.85 30');
+        resize('-38.72 -5.83 -50.45','28.73 33.85 30');
 	}
 	else
 	{
@@ -725,7 +725,7 @@ void() player_dead_face_down =
 	if (self.spawnflags & 1)
 	{
 		self.solid = SOLID_BBOX;
-               	setsize(self,'-50.28 -23.55 -49.85','30.66 14.49 30');
+        resize('-50.28 -23.55 -49.85','30.66 14.49 30');
 	}
 	else
 	{
@@ -751,7 +751,7 @@ void() player_dead_on_side =
 	if (self.spawnflags & 1)
 	{
 		self.solid = SOLID_BBOX;
-               	setsize(self,'-38.72 -5.83 -50.45','28.73 33.85 30');
+        resize('-38.72 -5.83 -50.45','28.73 33.85 30');
 	}
 	else
 	{

--- a/shalrath.qc
+++ b/shalrath.qc
@@ -362,7 +362,7 @@ void() monster_shalrath =
 
 	body_model ("progs/shalrath.mdl");
 	// setmodel (self, "progs/shalrath.mdl");
-	setsize (self, VEC_HULL2_MIN, VEC_HULL2_MAX);
+	resize(VEC_HULL2_MIN, VEC_HULL2_MAX);
 
 	if (!self.health) //thanks RennyC -- dumptruck_ds
 	self.health = 400;
@@ -423,7 +423,7 @@ void() monster_dead_shalrath =
 	if (self.spawnflags & 1)
 	{
 		self.solid = SOLID_BBOX;
-               	setsize(self,'-41.41 -40.06 -49.38','34.52 24.32 30');
+        resize('-41.41 -40.06 -49.38','34.52 24.32 30');
 	}
 	else
 	{

--- a/shambler.qc
+++ b/shambler.qc
@@ -661,7 +661,7 @@ void() monster_shambler =
 	body_model ("progs/shambler.mdl");
 	// setmodel (self, "progs/shambler.mdl");
 
-	setsize (self, VEC_HULL2_MIN, VEC_HULL2_MAX);
+	resize(VEC_HULL2_MIN, VEC_HULL2_MAX);
 
 	if (!self.health) //thanks RennyC -- dumptruck_ds
 	self.health = 600;
@@ -718,7 +718,7 @@ void() monster_dead_shambler =
         if (self.spawnflags & 1)
 	{
 		self.solid = SOLID_BBOX;
-                setsize(self,'-77.09 -72.17 -51.52','47.44 98.15 30');
+        resize('-77.09 -72.17 -51.52','47.44 98.15 30');
 	}
 	else
 	{

--- a/soldier.qc
+++ b/soldier.qc
@@ -634,7 +634,7 @@ void() monster_army =
 	//dumptruck_ds custom_mdls
 	body_model ("progs/soldier.mdl");
 
-	setsize (self, '-16 -16 -24', '16 16 40');
+	resize('-16 -16 -24', '16 16 40');
 
 	if (!self.proj_speed_mod)
 	{
@@ -686,7 +686,7 @@ void() monster_dead_army =
 		if (self.spawnflags & 1)
 		{
 			self.solid = SOLID_BBOX;
-                	setsize(self,'-38.27 -30.47 -50.3','22.1 25.35 30');
+            resize('-38.27 -30.47 -50.3','22.1 25.35 30');
 		}
 		else
 		{
@@ -699,7 +699,7 @@ void() monster_dead_army =
 		if (self.spawnflags & 1)
 		{
 			self.solid = SOLID_BBOX;
-                	setsize(self,'-39.85 -29.35 -49.07','20.52 33.17 30');
+            resize('-39.85 -29.35 -49.07','20.52 33.17 30');
 		}
 		else
 		{

--- a/spawn.qc
+++ b/spawn.qc
@@ -271,7 +271,7 @@ void() monster_tarbaby =
 	body_model ("progs/tarbaby.mdl"); //custom_mdls dumptruck_ds
 	// setmodel (self, "progs/tarbaby.mdl");
 
-	setsize (self, '-16 -16 -24', '16 16 40');
+	resize('-16 -16 -24', '16 16 40');
 
 	if (!self.health) //thanks RennyC -- dumptruck_ds
 	self.health = 80;

--- a/wizard.qc
+++ b/wizard.qc
@@ -528,7 +528,7 @@ void() monster_wizard =
 	body_model ("progs/wizard.mdl");
 	// setmodel (self, "progs/wizard.mdl"); //dumptruck_ds
 
-	setsize (self, '-16 -16 -24', '16 16 40');
+	resize('-16 -16 -24', '16 16 40');
 
 	if (!self.proj_speed_mod)
 	{
@@ -570,7 +570,7 @@ void() monster_dead_wizard =
 	if (self.spawnflags & 1)
 	{
 		self.solid = SOLID_BBOX;
-               	setsize(self,'-50.75 -27.46 -55.19','31.81 33.61 30');
+        resize('-50.75 -27.46 -55.19','31.81 33.61 30');
 	}
 	else
 	{

--- a/zombie.qc
+++ b/zombie.qc
@@ -135,7 +135,7 @@ void() zombie_run1              =[      $run1,          zombie_run2     ] {
 		{  // sloppy hack, but it fixes the illusionary zombie bug
 		body_model ("progs/zombie.mdl"); //custom_mdls dumptruck_ds
 		// setmodel (self, "progs/zombie.mdl");
-		setsize (self, '-16 -16 -24', '16 16 40');
+		resize('-16 -16 -24', '16 16 40');
 		}
 	ai_run(1);
 	self.inpain = 0;};
@@ -847,7 +847,7 @@ void() monster_zombie =
 	body_model ("progs/zombie.mdl"); //custom_mdls dumptruck_ds
 	// setmodel (self, "progs/zombie.mdl");
 
-	setsize (self, '-16 -16 -24', '16 16 40');
+	resize('-16 -16 -24', '16 16 40');
 	self.health = 61;
 
 	if (self.spawnflags & SPAWN_CRUCIFIED)


### PR DESCRIPTION
Progs_dump 3.0 offers unprecedented options to customize the Quake stock monsters with new models.
Yet if a replacement model is visually quite different in size from the original model it replaces, the monster hitbox needs to be adjusted accordingly (which is not supported by progs_dump 3.0).
The .mdlsz property is now supported by all monsters, dead monsters and various pickups to override their default size, and works the same as its implementation for misc_model in progs_dump 3.0.