### PR TITLE
Non rotating tracer

### DIFF
--- a/client.qc
+++ b/client.qc
@@ -852,14 +852,11 @@ void() CheckGrapple =
 		player_aim = player_offset + (v_forward * 200);
 		new.origin = player_aim;
 		
-		new.angles[2] = (time * 100) % 360;
+		if(!(trace_ent.spawnflags & /*Non rotating tracer*/4))
+			new.angles[2] = (time * 100) % 360;
 		new.alpha = (dist / 300) - (0.5);
-		if (trace_ent.mdl!="") {
-			setmodel (new, trace_ent.mdl);
-		}
-		else {
-			setmodel (new, "progs/tracer1.mdl");
-		}
+		setmodel (new, trace_ent.mdl);
+
 		setsize (new, '0 0 0', '0 0 0');
 		new.think = SUB_Remove;
 		new.ltime = time;

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -1700,6 +1700,7 @@ Player can move freely inside of this entity's volume, on walls and ceilings."
 	[
 		1 : "Aim only" : 0
 		2 : "Player noclip" : 0
+		4 : "Non rotating tracer" : 0
 	]
 ]
 

--- a/rm_mechanics.qc
+++ b/rm_mechanics.qc
@@ -328,7 +328,11 @@ void() func_hook =
 	if (self.noise3 != "") {
 		precache_sound(self.noise3);
 	}
-		
+	
+	if(!self.mdl)
+		self.mdl = "progs/tracer1.mdl";
+	precache_model(self.mdl);
+	
 	setmodel (self, self.model);
 	self.classname = "func_hook";
 	

--- a/world.qc
+++ b/world.qc
@@ -487,8 +487,6 @@ void() worldspawn =
 	
 // Re:Mobilize precaches
 
-	precache_model("progs/tracer1.mdl");
-
 	precache_sound ("misc/cushion1.wav");
 	precache_sound ("misc/cushion2.wav");
 	precache_sound ("misc/cushion3.wav");


### PR DESCRIPTION
Lightpanel tracers are not forced anymore to be rotating. This keeps being the default behavior but can be inhibited thanks to a new spawnflag.
Also, the tracer model precache is now performed in the func_hook spawn function instead of the world spawn function.