### PR TITLE
Various QOL edits

### DIFF
--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -2511,7 +2511,7 @@ MONSTER_ONLY(16) will only teleport monsters"
         3 : "Nightmare!"
 	]
 ]
-@PointClass base(Trigger) = trigger_relay : "Trigger: Relay"
+@PointClass base(Trigger) color(0 192 192)= trigger_relay : "Trigger: Relay"
 [
 ]
 @SolidClass base(Appearflags, TriggerWait) = trigger_take_weapon : "

--- a/misc.qc
+++ b/misc.qc
@@ -1069,21 +1069,21 @@ float TOGGLEVISWALL_NOTSOLID = 2;
 
 void() func_togglevisiblewall_use =
 {
-	if(!self.state) {
+	if(!self.estate) {
 		if(!(self.spawnflags & TOGGLEVISWALL_NOTSOLID)) {
 			self.solid = SOLID_BSP;
 			self.movetype = MOVETYPE_PUSH;
 		}
 		setmodel (self, self.origmodel);
 		if(self.switchshadstyle) lightstyle(self.switchshadstyle, "a");
-		self.state = 1;
+		self.estate = 1;
 	} else {
 
 		self.solid = SOLID_NOT;
 		self.movetype = MOVETYPE_NONE;
 		setmodel (self, "");
 		if(self.switchshadstyle) lightstyle(self.switchshadstyle, "m");
-		self.state = 0;
+		self.estate = 0;
 	}
 
 };
@@ -1098,8 +1098,8 @@ void() func_togglevisiblewall =
 
 	self.origmodel = self.model;
 
-	if(self.spawnflags & TOGGLEVISWALL_STARTOFF) self.state = 1;
-	else self.state = 0;
+	if(self.spawnflags & TOGGLEVISWALL_STARTOFF) self.estate = 1;
+	else self.estate = 0;
 
 	if(self.spawnflags & TOGGLEVISWALL_NOTSOLID) {
 		self.solid = SOLID_NOT;

--- a/misc_model.qc
+++ b/misc_model.qc
@@ -46,14 +46,12 @@ void() misc_model_use = {
 		self.model = "";
 
 		self.state = STATE_INVISIBLE;
-		setorigin(self, self.origin);
 	}
 	else {
 		if (self.spawnflags & MISC_MODEL_SOLID) self.solid = SOLID_BBOX;
 		self.model = self.mdl;
 
 		self.state = STATE_ACTIVE;
-		setorigin(self, self.origin);
 	}
 };
 
@@ -81,6 +79,7 @@ void() misc_model = {
     setmodel(self, self.mdl);
     
 	setsize(self, vmin, vmax);
+	setorigin(self, self.origin);
 	
 	if(self.spawnflags & MISC_MODEL_SOLID) self.solid = SOLID_BBOX;
 	else self.solid = SOLID_NOT;


### PR DESCRIPTION
* trigger_relay now appear in light blue in TrenchBroom to stand out more (old habit of trying to give each entity type a distinctive color instead of always the same white cube for everybody)
* func_togglevisiblewall implementation now based on its .estate property instead of .state --> It allows a fine control over the visibility/invisibility through target_setstate.
* misc_model had its origin set in its use function, which was not logical and made the property unavailable for misc_model entities not needing to be used, or not having been used yet.