### PR TITLE
Trigger spawn mid-air then drop to floor

### DIFF
--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -359,10 +359,11 @@ the bprint tends to stomp any other prints on screen in most quake clients, so u
 		32 : "Spawn Silently" : 0
 		64 : "Trigger spawned" : 0
 		128 : "Suspended in air" : 0
+		4194304 : "Spawn then drop" : 0
 		8388608 : "Don't drop to floor" : 0
 	]
 	// message(string) : "Message"
-	// delay(integer) : "Delay"
+	delay(float) : "If 'Spawn then drop', delay before falling down" : 0.2
 ]
 
 @BaseClass base(NonRespawnableItem) =
@@ -1828,8 +1829,8 @@ By default it'll fire for each and every registered touch, even if simultaneous.
 ]
 
 
-@PointClass base(Appearflags, Targetname) = target_setcount : "Changes the targeted entity's 'count' field. Targets both targetname and targetname2 fields.
-Can be used with a trigger_filter to dinamically change its comparing value, or to reset/change a trigger_counter's current use count.
+@PointClass base(Appearflags, Targetname) = target_setcount : "Changes the targeted entity's 'count' field. Targets targetname, targetname2, targetname3 and targetname4 fields.
+Can be used with a trigger_filter to dynamically change its comparing value, or to reset/change a trigger_counter's current use count.
 
 You can either replace the current value with a new one, or add/subtract to it (by using a positive or negative 'count'), by selecting into the 'style' field.
 "

--- a/items.qc
+++ b/items.qc
@@ -7,6 +7,7 @@ float ITEM_SPAWNSILENT = 32;
 float ITEM_SPAWNED = 64;
 float ITEM_SUSPENDED = 128;
 float ITEM_RESPAWNDM = 16384;
+float ITEM_SPAWNFALL = 4194304;
 float ITEM_DONTDROP = 8388608;
 
 .vector particles_offset;
@@ -88,7 +89,16 @@ void() DelaySpawnItem =
 		// sound (self, CHAN_VOICE, "items/itembk2.wav", 1, ATTN_NORM);
 		spawn_tfog (self.origin + self.particles_offset);
 
-	if (self.spawnflags & ITEM_SUSPENDED)
+	if (self.spawnflags & ITEM_SPAWNFALL)
+	{
+		self.movetype = MOVETYPE_FLY;
+		self.think = droptofloor;
+		if(self.delay)
+			self.nextthink = time + self.delay;
+		else
+			self.nextthink = time + 0.2;
+	}
+	else if (self.spawnflags & ITEM_SUSPENDED)
 		self.movetype = MOVETYPE_FLY;
 	else
 		self.movetype = MOVETYPE_TOSS;
@@ -123,7 +133,7 @@ void() PlaceItem =
 	self.solid = SOLID_TRIGGER;
 	self.velocity = '0 0 0';
 
-	if (self.spawnflags & ITEM_SUSPENDED)  //ijed Don't drop spawnflag
+	if (self.spawnflags & ITEM_SUSPENDED || self.spawnflags & ITEM_SPAWNFALL)  //ijed Don't drop spawnflag
 	{
 		self.movetype = MOVETYPE_FLY;
 	}
@@ -169,7 +179,7 @@ void() PlaceItem =
 		}
 	}
 
-	if ((self.spawnflags & ITEM_SPAWNED))		// SPAWNED, gb
+	if (self.spawnflags & ITEM_SPAWNED || self.spawnflags & ITEM_SPAWNFALL)		// SPAWNED, gb
 	{
 		self.pos1 = self.mins;
 		self.pos2 = self.maxs;

--- a/items.qc
+++ b/items.qc
@@ -79,6 +79,8 @@ DelaySpawnItem //this is from rmq-items.qc
 Makes a SPAWNED item ready for pickup on a trigger event - modified a bit -- dumptruck_ds
 ============
 */
+void() DropToFloor = { droptofloor(); }
+
 void() DelaySpawnItem =
 {
 	self.solid = SOLID_TRIGGER;
@@ -92,7 +94,7 @@ void() DelaySpawnItem =
 	if (self.spawnflags & ITEM_SPAWNFALL)
 	{
 		self.movetype = MOVETYPE_FLY;
-		self.think = droptofloor;
+		self.think = DropToFloor;
 		if(self.delay)
 			self.nextthink = time + self.delay;
 		else


### PR DESCRIPTION
A variant spawnflag working essentially like 'Trigger spawn' except if the item is waiting mid-air to be spawned it spawns there and then only falls down on the floor.