### PR TITLE
func_playerclip

### DIFF
--- a/client.qc
+++ b/client.qc
@@ -919,6 +919,27 @@ void() CheckGrapple =
 
 }
 
+void(string target_class) MakeClassSolid =
+{
+    entity e;
+    e = world;
+    while( (e = find(e, classname, target_class)) )
+    {
+        e.solid = SOLID_BSP;
+        e.movetype = MOVETYPE_PUSH;
+    }
+};
+ 
+void(string target_class) MakeClassNonSolid =
+{
+    entity e;
+    e = world;
+    while( (e = find(e, classname, target_class)) )
+    {
+        e.solid = SOLID_NOT;
+        e.movetype = MOVETYPE_NONE;
+    }
+};
 
 /*
 ================
@@ -990,6 +1011,8 @@ void() PlayerPreThink =
 	if (cleanUpClientStuff)
 		fog_setFromEnt(self, self);
 
+	MakeClassSolid("func_playerclip");
+	
 	makevectors (self.v_angle);		// is this still used
 
 	CheckRules ();
@@ -1394,6 +1417,8 @@ void() PlayerPostThink =
 	if (self.deadflag)
 		return;
 
+	MakeClassNonSolid("func_playerclip");
+	
 // do weapon stuff
 
 	W_WeaponFrame ();

--- a/doors.qc
+++ b/doors.qc
@@ -950,3 +950,11 @@ void () func_door_secret =
 	if (!self.wait)
 		self.wait = 5;		// 5 seconds before closing
 };
+
+/*QUAKED func_playerclip
+A bbox entity which is solid for the player only
+*/
+void() func_playerclip =
+{
+	setmodel (self, self.model);	// set size and link into world
+};

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -3722,3 +3722,5 @@ Example: 3 targets of impulse respectively 3, 2 and 1 --> Total cumulated impuls
 	killtarget(target_destination) : "Killtarget (fired upon entering the trigger)"
 	killtarget2(target_destination) : "Killtarget2 (fired upon leaving the trigger)"
 ]
+
+@SolidClass base(Appearflags, Targetname) = func_playerclip : "A bbox entity which is solid for the player only" []


### PR DESCRIPTION
func_playerclip is an opaque brush which is solid to the player only.
Monsters can see and walk through it.
Essentially meant for allowing the use of monsters like fiends or shamblers in narrow spaces where the player wouldn't expect them: make the archways as func_playerclips and the monsters' hitboxes won't bump so awkwardly in the geometry.
The outcome is pretty spectacular and tense (see how the fiend in [Church of the Unholy](https://www.moddb.com/mods/church-of-the-unholy)'s low vaulted undergrounds works damn well).