### PR TITLE
func_playerclip (new implementation)

### DIFF
--- a/client.qc
+++ b/client.qc
@@ -919,6 +919,20 @@ void() CheckGrapple =
 
 }
 
+void(float makeSolid) MakePlayerClipSolid =
+{
+    entity e = world;
+	entity oself = self;
+    while( (e = find(e, classname, "func_playerclip")) )
+    {
+		if(e.estate != makeSolid)
+		{
+			self = e;
+			self.use();
+        }
+    }
+	self = oself;
+};
 
 /*
 ================
@@ -990,6 +1004,8 @@ void() PlayerPreThink =
 	if (cleanUpClientStuff)
 		fog_setFromEnt(self, self);
 
+	MakePlayerClipSolid(TRUE);
+	
 	makevectors (self.v_angle);		// is this still used
 
 	CheckRules ();
@@ -1394,6 +1410,8 @@ void() PlayerPostThink =
 	if (self.deadflag)
 		return;
 
+	MakePlayerClipSolid(FALSE);
+	
 // do weapon stuff
 
 	W_WeaponFrame ();

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -1987,6 +1987,9 @@ Effects will require an origin brush to work properly (see func_fall2 in manual 
 
 @SolidClass base(Appearflags, Targetname, Effects, ModelLight) = func_togglevisiblewall : "A bmodel which you can toggle its visibility. Behaves much like a traditional func_wall in any other way, but you can target it to toggle visible/invisible.
 If the entity has a switchable shadow it also toggles automatically (no need for a shadow controller)."
+If the entity has a switchable shadow it also toggles automatically (no need for a shadow controller).
+Although odd to the entity's name, the 'Keep visible' spawnflag allows to switch the wall solidity only, while keeping it visible all time. The shadow may or may not be switched at the occasion.
+"
 [
 	spawnflags(flags) =
 	[
@@ -3728,15 +3731,6 @@ Example: 3 targets of impulse respectively 3, 2 and 1 --> Total cumulated impuls
 'activator' is suited in conjunction with trigger_filter (eg to filter a breakable statue's health level and change its frame to a damaged version below a certain amount).
 'other' is suited when... Who knows, there's probably a case when it might be useful!
 "
-[
-    frame(integer) : "The new frame value"
-	target(choices) : "The entity to change" =
-	[
-		"activator" : "activator"
-		"other" : "other"
-	]
-]
-
 @SolidClass color(181 132 93) base(Appearflags, Targetname) = trigger_enterleave : "A trigger that fires its targets when entering it, leaving it, or both.
 
 'target' and 'target2' are the targets fired upon entering the trigger.
@@ -3753,3 +3747,5 @@ Example: 3 targets of impulse respectively 3, 2 and 1 --> Total cumulated impuls
 	killtarget(target_destination) : "Killtarget (fired upon entering the trigger)"
 	killtarget2(target_destination) : "Killtarget2 (fired upon leaving the trigger)"
 ]
+
+@SolidClass base(Appearflags, Targetname) = func_playerclip : "A bbox entity which is solid for the player only" []

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -1995,6 +1995,7 @@ Although odd to the entity's name, the 'Keep visible' spawnflag allows to switch
 	[
 		1 : "Start Off" : 0
 		2 : "Non-solid" : 0
+		4 : "Keep visible" : 0
 	]
 	_switchableshadow(choices) : "Switchable shadow" : 0 : "Enables dynamic shadows that toggle on/off with the entity" = [
 		0: "No"

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -1986,10 +1986,8 @@ Originally unused in the game. Plays the sound of thunder at a random interval. 
 Effects will require an origin brush to work properly (see func_fall2 in manual for details)" []
 
 @SolidClass base(Appearflags, Targetname, Effects, ModelLight) = func_togglevisiblewall : "A bmodel which you can toggle its visibility. Behaves much like a traditional func_wall in any other way, but you can target it to toggle visible/invisible.
-If the entity has a switchable shadow it also toggles automatically (no need for a shadow controller)."
 If the entity has a switchable shadow it also toggles automatically (no need for a shadow controller).
-Although odd to the entity's name, the 'Keep visible' spawnflag allows to switch the wall solidity only, while keeping it visible all time. The shadow may or may not be switched at the occasion.
-"
+Although odd to the entity's name, the 'Keep visible' spawnflag allows to switch the wall solidity only, while keeping it visible all time. The shadow may or may not be switched at the occasion."
 [
 	spawnflags(flags) =
 	[
@@ -3732,6 +3730,15 @@ Example: 3 targets of impulse respectively 3, 2 and 1 --> Total cumulated impuls
 'activator' is suited in conjunction with trigger_filter (eg to filter a breakable statue's health level and change its frame to a damaged version below a certain amount).
 'other' is suited when... Who knows, there's probably a case when it might be useful!
 "
+[
+    frame(integer) : "The new frame value"
+	target(choices) : "The entity to change" =
+	[
+		"activator" : "activator"
+		"other" : "other"
+	]
+]
+
 @SolidClass color(181 132 93) base(Appearflags, Targetname) = trigger_enterleave : "A trigger that fires its targets when entering it, leaving it, or both.
 
 'target' and 'target2' are the targets fired upon entering the trigger.

--- a/misc.qc
+++ b/misc.qc
@@ -1081,7 +1081,7 @@ void() func_togglevisiblewall_use =
 
 		self.solid = SOLID_NOT;
 		self.movetype = MOVETYPE_NONE;
-		setmodel (self, "");
+		if(!(self.spawnflags & /*Keep visible*/4)) setmodel (self, "");
 		if(self.switchshadstyle) lightstyle(self.switchshadstyle, "m");
 		self.estate = 0;
 	}
@@ -1110,6 +1110,15 @@ void() func_togglevisiblewall =
 
 };
 
+/*QUAKED func_playerclip
+A bbox entity which is solid for the player only
+*/
+void() func_playerclip =
+{
+	self.targetname=self.targetname2=self.targetname3=self.targetname4=string_null;
+	self.spawnflags = /*Keep visible*/4;
+	func_togglevisiblewall();
+};
 
 /*****************
 func_shadow


### PR DESCRIPTION
func_playerclip is an opaque brush which is solid to the player only.
Monsters can see and walk through it.
Essentially meant for allowing the use of monsters like fiends or shamblers in narrow spaces where the player wouldn't expect them: make the archways as func_playerclips and the monsters' hitboxes won't bump so awkwardly in the geometry.
The outcome is pretty spectacular and tense (see how the fiend in [Church of the Unholy](https://www.moddb.com/mods/church-of-the-unholy)'s low vaulted undergrounds works damn well).

This is the second implementation of the entity, the first one not working on non-FTE engines for some unexplained reason.
This implementation is built on top of func_togglevisiblewall.

func_togglevisiblewall gains a new spawnflag at the occasion : 'Keep visible'
(required by func_playerclip, but possibly useful for mappers too)