### PR TITLE
Custom item bounding box

### DIFF
--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -364,6 +364,8 @@ the bprint tends to stomp any other prints on screen in most quake clients, so u
 	]
 	// message(string) : "Message"
 	delay(float) : "If 'Spawn then drop', delay before falling down" : 0.2
+	mdlsz(string) : "Entity size (x y z). Special value '-1 -1 -1' actually means '0 0 0' (zero-sized)"
+	centeroffset(string) : "Offset (x y z) applied to the entity model from the center of its bounding box (applies only if mdlsz is set)"
 ]
 
 @BaseClass base(NonRespawnableItem) =

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -364,7 +364,7 @@ the bprint tends to stomp any other prints on screen in most quake clients, so u
 	]
 	// message(string) : "Message"
 	delay(float) : "If 'Spawn then drop', delay before falling down" : 0.2
-	mdlsz(string) : "Entity size (x y z). Special value '-1 -1 -1' actually means '0 0 0' (zero-sized)"
+	mdlsz(string) : "Entity size (x y z). To ensure compatibility across engines, avoid '0 0 0' (zero-sized)"
 	centeroffset(string) : "Offset (x y z) applied to the entity model from the center of its bounding box (applies only if mdlsz is set)"
 ]
 

--- a/items.qc
+++ b/items.qc
@@ -217,11 +217,7 @@ Sets the clipping size and plants the object on the floor
 */
 void() StartItem =
 {
-	if(self.mdlsz == '-1 -1 -1')
-	{
-		setsize (self, '0 0 0',  '0 0 0');
-	}
-	else if(self.mdlsz)
+	if(self.mdlsz)
 	{
 		vector vmin, vmax;
 		

--- a/items.qc
+++ b/items.qc
@@ -205,6 +205,27 @@ Sets the clipping size and plants the object on the floor
 */
 void() StartItem =
 {
+	if(self.mdlsz == '-1 -1 -1')
+	{
+		setsize (self, '0 0 0',  '0 0 0');
+	}
+	else if(self.mdlsz)
+	{
+		vector vmin, vmax;
+		
+		if(!self.centeroffset) self.centeroffset = '0 0 0';
+		
+		vmin_x = self.centeroffset_x - (self.mdlsz_x / 2);
+		vmin_y = self.centeroffset_y - (self.mdlsz_y / 2);
+		vmin_z = self.centeroffset_z - (self.mdlsz_z / 2);
+
+		vmax_x = self.centeroffset_x + (self.mdlsz_x / 2);
+		vmax_y = self.centeroffset_y + (self.mdlsz_y / 2);
+		vmax_z = self.centeroffset_z + (self.mdlsz_z / 2);
+
+		setsize(self, vmin, vmax);
+	}
+
 	self.nextthink = time + 0.3;	// items start after other solids || was 0.2 -- dumptruck_ds
 	self.think = PlaceItem;
 };

--- a/rm_mechanics.qc
+++ b/rm_mechanics.qc
@@ -459,7 +459,7 @@ void() target_autohook_dehook =
 					e.velocity[0] = 0;
 					e.velocity[1] = 0;
 					e.movetype = MOVETYPE_TOSS;
-					e.think = DropToFloor;
+					e.think = SUB_Null;
 					e.nextthink = time + 0.2;
 				}
 				else if (e.flags & FL_MONSTER) {

--- a/triggers.qc
+++ b/triggers.qc
@@ -2115,6 +2115,7 @@ void() trigger_enterleave_leave =
 		self.target = "";
 		self.target2 = "";
 		self.killtarget = "";
+		activator = other;
 		SUB_UseTargets();
 		self.target = otarget;
 		self.target2 = otarget2;


### PR DESCRIPTION
Since items may be represented by custom models, it may be useful to adjust the size of their bounding box.
For that purpose, the mdlsz is now supported (like it previously was for monsters).
The visual offset of the mdl model inside the bounding box can additionally be adjusted thanks to the centeroffset property.