### PR TITLE
Customizable tracer distance

### DIFF
--- a/client.qc
+++ b/client.qc
@@ -852,7 +852,7 @@ void() CheckGrapple =
 			self.volume = 0;
 		}
 		
-		player_aim = player_offset + (v_forward * 200);
+		player_aim = player_offset + (v_forward * trace_ent.distance);
 		new.origin = player_aim;
 		
 		if(!(trace_ent.spawnflags & /*Non rotating tracer*/4))

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -1744,6 +1744,8 @@ Spawnflags:
 	
 	mdl(string) : "Model file for the tracer."
 	
+	distance(integer) : "Distance from the player the tracer model shows up." : 200
+	
 	spawnflags(Flags) =
 	[
 		1 : "Aim only" : 0

--- a/rm_mechanics.qc
+++ b/rm_mechanics.qc
@@ -335,6 +335,9 @@ void() func_hook =
 		precache_sound(self.noise3);
 	}
 	
+	if(!self.distance)
+		self.distance = 200;
+		
 	if(!self.mdl)
 		self.mdl = "progs/tracer1.mdl";
 	precache_model(self.mdl);


### PR DESCRIPTION
The distance the lightpanel tracer model shows up in from of the player is usually 200 units.
It can now be customized thanks to the .distance property.
Useful in case of aim-only use of a lightpanel in a cramped space.