### PR TITLE
trigger_changetarget enhanced

### DIFF
--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -2707,12 +2707,16 @@ If you want to make them angry at each other instantly, you can set the spawnfla
 [
     target(target_destination) : "The entity to change"
     message(target_destination) : "The new target value"
-		cnt(choices) : "Target field to modify. No value defaults to 'target'" : 0 = [
-			1 : "target"
-			2 : "target2"
-			3 : "target3"
-			4 : "target4"
-		]
+	cnt(choices) : "Target field to modify. No value defaults to 'target'" : 0 =
+	[
+		1 : "target"
+		2 : "target2"
+		3 : "target3"
+		4 : "target4"
+		-1 : "killtarget"
+		-2 : "killtarget2"
+		-3 : "paintarget"
+	]
 ]
 @PointClass base(Appearflags, Targetname) = target_setstate : "Changes an entity's state.
 Entities in a disabled state won't execute its main function, depending on context.

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -2713,6 +2713,7 @@ If you want to make them angry at each other instantly, you can set the spawnfla
 		2 : "target2"
 		3 : "target3"
 		4 : "target4"
+		5 : "message"
 		-1 : "killtarget"
 		-2 : "killtarget2"
 		-3 : "paintarget"

--- a/triggers.qc
+++ b/triggers.qc
@@ -1441,6 +1441,7 @@ void() trigger_target_change_use =
 			case  2:	e.target2 =     self.message; break;
 			case  3:	e.target3 =     self.message; break;
 			case  4:	e.target4 =     self.message; break;
+			case  5:	e.message =     self.message; break;
 			default:	e.target =      self.message; break;
 		}
 		e = find(e, targetname, self.target);
@@ -1458,6 +1459,7 @@ void() trigger_target_change_use =
 			case  2:	e.target2 =     self.message; break;
 			case  3:	e.target3 =     self.message; break;
 			case  4:	e.target4 =     self.message; break;
+			case  5:	e.message =     self.message; break;
 			default:	e.target =      self.message; break;
 		}
 		e = find(e, targetname2, self.target);
@@ -1475,6 +1477,7 @@ void() trigger_target_change_use =
 			case  2:	e.target2 =     self.message; break;
 			case  3:	e.target3 =     self.message; break;
 			case  4:	e.target4 =     self.message; break;
+			case  5:	e.message =     self.message; break;
 			default:	e.target =      self.message; break;
 		}
 		e = find(e, targetname3, self.target);
@@ -1492,6 +1495,7 @@ void() trigger_target_change_use =
 			case  2:	e.target2 =     self.message; break;
 			case  3:	e.target3 =     self.message; break;
 			case  4:	e.target4 =     self.message; break;
+			case  5:	e.message =     self.message; break;
 			default:	e.target =      self.message; break;
 		}
 		e = find(e, targetname4, self.target);

--- a/triggers.qc
+++ b/triggers.qc
@@ -1425,27 +1425,78 @@ void() trigger_look =
 
 void() trigger_target_change_use =
 {
+	entity e;
+	
 	if (self.estate != STATE_ACTIVE) return;
 
-    for (entity e = world; (e = find(e, targetname, self.target)); )
-    {
-      if (!self.cnt || self.cnt == 1)
-      {
-        e.target = self.message;
-      }
-      else if (self.cnt == 2)
-      {
-        e.target2 = self.message;
-      }
-      else if (self.cnt == 3)
-      {
-        e.target3 = self.message;
-      }
-      else if (self.cnt == 4)
-      {
-        e.target4 = self.message;
-      }
-    }
+	//Search target by targetname
+	e = find(world, targetname, self.target);
+	while(e != world)
+	{
+		switch(self.cnt)
+		{
+			case -1:	e.killtarget  = self.message; break;
+			case -2:	e.killtarget2 = self.message; break;
+			case -3:	e.pain_target = self.message; break;
+			case  2:	e.target2 =     self.message; break;
+			case  3:	e.target3 =     self.message; break;
+			case  4:	e.target4 =     self.message; break;
+			default:	e.target =      self.message; break;
+		}
+		e = find(e, targetname, self.target);
+	}
+
+	//Search target by targetname2
+	e = find(world, targetname2, self.target);
+	while(e != world)
+	{
+		switch(self.cnt)
+		{
+			case -1:	e.killtarget  = self.message; break;
+			case -2:	e.killtarget2 = self.message; break;
+			case -3:	e.pain_target = self.message; break;
+			case  2:	e.target2 =     self.message; break;
+			case  3:	e.target3 =     self.message; break;
+			case  4:	e.target4 =     self.message; break;
+			default:	e.target =      self.message; break;
+		}
+		e = find(e, targetname2, self.target);
+	}
+
+	//Search target by targetname3
+	e = find(world, targetname3, self.target);
+	while(e != world)
+	{
+		switch(self.cnt)
+		{
+			case -1:	e.killtarget  = self.message; break;
+			case -2:	e.killtarget2 = self.message; break;
+			case -3:	e.pain_target = self.message; break;
+			case  2:	e.target2 =     self.message; break;
+			case  3:	e.target3 =     self.message; break;
+			case  4:	e.target4 =     self.message; break;
+			default:	e.target =      self.message; break;
+		}
+		e = find(e, targetname3, self.target);
+	}
+
+	//Search target by targetname4
+	e = find(world, targetname4, self.target);
+	while(e != world)
+	{
+		switch(self.cnt)
+		{
+			case -1:	e.killtarget  = self.message; break;
+			case -2:	e.killtarget2 = self.message; break;
+			case -3:	e.pain_target = self.message; break;
+			case  2:	e.target2 =     self.message; break;
+			case  3:	e.target3 =     self.message; break;
+			case  4:	e.target4 =     self.message; break;
+			default:	e.target =      self.message; break;
+		}
+		e = find(e, targetname4, self.target);
+	}
+
 };
 
 


### PR DESCRIPTION
Previously trigger_changetarget was only able to
* target entities by targetname
* Change its targets' target-target4 properties

Now also able to:
* target entities by targetname2-4
* Change its targets' killtarget, killtarget2 and pain_target properties
