### PR TITLE
Trigger_random's pain_target

### DIFF
--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -3729,6 +3729,7 @@ Example: 3 targets of impulse respectively 3, 2 and 1 --> Total cumulated impuls
 	[
 		1 : "Consume" : 0
 	]
+	pain_target(string) : "Target(s) to fire when no entity whose targetname is self.target was found (e.g. once all the targets were consumed)"
 ]
 
 @PointClass color(181 132 93) base(Appearflags, Targetname) = trigger_changeskin : "Changes the skin field on an entity.

--- a/triggers.qc
+++ b/triggers.qc
@@ -2027,6 +2027,15 @@ void trigger_random_use ()
 		self.target = targ.targetname = oldtargetname;
 		if(self.spawnflags&/*Consume*/1) targ.estate = STATE_INACTIVE; //This target is no longer able to be fired
 	}
+	else
+	{
+		//When no (more) primary target is found, fire pain_target entities instead
+		string oldPainTarget= self.pain_target;
+		SUB_UsePain();
+		
+		//Reset pain_target to its initial value (for some reason it's automatically hard-reset to "" at the end of SUB_UsePain)
+		self.pain_target = oldPainTarget;
+	}
 }
 
 void trigger_random ()


### PR DESCRIPTION
pain_target is a new addition to trigger_random: target(s) to fire when no entity whose targetname matches self.target was found.
Useful once all the random targets were consumed.
Also interesting with only 1 random target (which is not so random anymore since its probability is 1): if the target exists then it's fired, otherwise pain_target is fired. It can be extremely useful even out of "random" scenarios.