### PR TITLE
Exploding trains

### DIFF
--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -2244,6 +2244,11 @@ Spawnflags:
 - 'Stop on trigger' will stop the train at the next path_corner when triggered. Trigger it again to resume.
 The flags above are mutually exclusive and will cause an objerror when selected simultaneously.
 - 'Custom alignment' allows you to directly specify how the train is offset relative to its path_corners using an 'origin' brush instead of using the vanilla corner alignment.
+- 'Breakable' turns the train into a moving func_breakable.
+  Special rules then apply:
+  * Use the visitflag property as the train's ''spawnflags as a breakable''
+  * Use noise3 as the breaking sound
+  * Use the same settings as func_breakable for the rest (number of chunks, model used, style, etc.)
 "
 [
 	sounds(choices) : "Sound" : 1 =
@@ -2266,11 +2271,55 @@ The flags above are mutually exclusive and will cause an objerror when selected 
 		4: "Stop on trigger" : 0
 		8: "Non-solid" : 0
 		64: "Custom alignment" : 0
+		128: "Breakable" : 0
+	]
+	visitflag(flags) =
+	[
+		1 :	"No Monster Damage" : 0 : "Only the player can break"
+		2 : "Explosion" : 0 : "Produces explosion effect and sound"
+		4 : "Use custom mdls or bsp models" : 0 : "Uses models specified in break_template1, 2, etc"
+		8 : "Cascading destruction" : 0 : "Bouncing debris can break func_breakables in turn"
+	]
+	noise3(string) : "Path to custom break sound (breakable trains only)"
+	style(choices) : "Built-in debris style (breakable trains only)" : 0 =
+	[
+		0 : "Green Metal (default)"
+		1 : "Red Metal"
+		2 : "Concrete"
+		3 : "Pine wood -- wood1_1"
+		4 : "Brown wood -- wizwood1_3"
+		5 : "Red wood -- dung01_2"
+		6 : "Stained Glass Yellow Flames -- window02_1"
+		7 : "Stained Glass Red Rays -- window01_4"
+		8 : "Stained Glass Yellow Dragon -- window01_3"
+		9 : "Stained Glass Blue Dragon -- window01_2"
+		10 : "Stained Glass Red Dragon -- window01_1"
+		11 : "Light Copper -- cop2_3"
+		12 : "Dark Copper -- cop1_1"
+		13 : "Tan Bricks Large -- wiz1_4"
+		14 : "Brown Bricks Large -- wbrick1_5"
+		15 : "Green Bricks Large -- wswamp2_1"
+		16 : "Generic Light Brown -- tlight08"
+		17 : "Red Brown Computer -- comp1_5"
+		18 : "Grey Black Computer -- comp1_1"
+		19 : "Blue Green Metal -- metal4_5"
+		20 : "Blue Green Runic Wall -- metal4_4"
+		21 : "Brown Metal -- metal2_2"
+		22 : "Dark Brown Metal -- metal1_3"
+		23 : "Medium Brown Metal -- metal1_2"
+		24 : "Blue Metal -- m5_8"
+		25 : "Green Stonework -- city8_2"
+		26 : "Blue Stonework -- city6_7"
+		27 : "Brown Bricks -- city2_8"
+		28 : "Tan Blue Bricks -- city2_7"
+		29 : "Red Bricks -- city2_1"
+		30 : "Blue Bricks -- city2_5"
+		31 : "Metal Rivets -- wizmet1_2"
 	]
 ]
 
 
-@PointClass base(Targetname) studio({ "path" : mdl, "skin" : skin, "frame" : first_frame}) = misc_modeltrain :
+@PointClass base(Appearflags, Targetname) studio({ "path" : mdl, "skin" : skin, "frame" : first_frame}) = misc_modeltrain :
 "Trains are moving platforms that players can ride. The target's origin specifies the min point of the train at each corner. The train spawns at the first target it is pointing at.
 Use path_corner as targets.
 If given a targetname, it'll only start moving after triggered.
@@ -2289,6 +2338,11 @@ If you want to explicitly set frame 0 in any '*_frame' fields, you must use -1 i
 Spawnflags:
 - No rotation: model doesn't rotate when moving towards path_corners.
 - Rotate Y only: model only rotates around the Y axis, so pitch/roll angles are kept as initially set (useful to fake walking NPCs).
+- 'Breakable' turns the train into a moving func_breakable.
+  Special rules then apply:
+  * Use the visitflag property as the train's ''spawnflags as a breakable''
+  * Use noise3 as the breaking sound
+  * Use the same settings as func_breakable for the rest (number of chunks, model used, style, etc.)
 "
 [
 	sounds(choices) : "Sound" : 1 =
@@ -2331,6 +2385,50 @@ Spawnflags:
 		8: "Non-solid" : 0
 		16: "No rotation" : 0
 		32: "Rotate Y only" : 0
+		128: "Breakable" : 0
+	]
+	visitflag(flags) =
+	[
+		1 :	"No Monster Damage" : 0 : "Only the player can break"
+		2 : "Explosion" : 0 : "Produces explosion effect and sound"
+		4 : "Use custom mdls or bsp models" : 0 : "Uses models specified in break_template1, 2, etc"
+		8 : "Cascading destruction" : 0 : "Bouncing debris can break func_breakables in turn"
+	]
+	noise3(string) : "Path to custom break sound (breakable trains only)"
+	style(choices) : "Built-in debris style (breakable trains only)" : 0 =
+	[
+		0 : "Green Metal (default)"
+		1 : "Red Metal"
+		2 : "Concrete"
+		3 : "Pine wood -- wood1_1"
+		4 : "Brown wood -- wizwood1_3"
+		5 : "Red wood -- dung01_2"
+		6 : "Stained Glass Yellow Flames -- window02_1"
+		7 : "Stained Glass Red Rays -- window01_4"
+		8 : "Stained Glass Yellow Dragon -- window01_3"
+		9 : "Stained Glass Blue Dragon -- window01_2"
+		10 : "Stained Glass Red Dragon -- window01_1"
+		11 : "Light Copper -- cop2_3"
+		12 : "Dark Copper -- cop1_1"
+		13 : "Tan Bricks Large -- wiz1_4"
+		14 : "Brown Bricks Large -- wbrick1_5"
+		15 : "Green Bricks Large -- wswamp2_1"
+		16 : "Generic Light Brown -- tlight08"
+		17 : "Red Brown Computer -- comp1_5"
+		18 : "Grey Black Computer -- comp1_1"
+		19 : "Blue Green Metal -- metal4_5"
+		20 : "Blue Green Runic Wall -- metal4_4"
+		21 : "Brown Metal -- metal2_2"
+		22 : "Dark Brown Metal -- metal1_3"
+		23 : "Medium Brown Metal -- metal1_2"
+		24 : "Blue Metal -- m5_8"
+		25 : "Green Stonework -- city8_2"
+		26 : "Blue Stonework -- city6_7"
+		27 : "Brown Bricks -- city2_8"
+		28 : "Tan Blue Bricks -- city2_7"
+		29 : "Red Bricks -- city2_1"
+		30 : "Blue Bricks -- city2_5"
+		31 : "Metal Rivets -- wizmet1_2"
 	]
 ]
 
@@ -3106,6 +3204,7 @@ Use spawnflag 2 for an explosion, dmg is amount of damage inflicted" [
 	        2 : "Explosion" : 0 : "Produces explosion effect and sound"
 	        4 : "Use custom mdls or bsp models" : 0 : "Uses models specified in break_template1, 2, etc"
 			8 : "Cascading destruction" : 0 : "Bouncing debris can break func_breakables in turn"
+			128 : "DO NOT USE" : 0 : "Reserved for breakable trains"
 	    ]
 		snd_hit(string) : "Path to custom impact sound for bouncing debris"
 		dmg_take(integer) : "Damage inflicted by each debris on touch"

--- a/plats.qc
+++ b/plats.qc
@@ -469,6 +469,9 @@ void() func_train =
 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
 		return;
 
+	if (self.takedamage == DAMAGE_YES)
+		func_breakable();
+	
 	if (!self.speed)
 		self.speed = 100;
 	if (!self.target)

--- a/plats.qc
+++ b/plats.qc
@@ -251,7 +251,7 @@ void() train_use = {
 	
 	// Train has already moved after startup, and has no "stop on trigger" flag,
 	// so ignore activation.
-	if (self.think != func_train_find && self.cnt != TRAIN_NEXT_STOP)
+	if (self.think != func_train_find && self.plat2GoTo != TRAIN_NEXT_STOP)
 		return;
 
 	train_next();
@@ -261,9 +261,9 @@ void() train_use = {
 // Forces a stop or an instant continue on the next path_corner depending on the spawnflag set
 void() train_moving_use = {
 	if (self.spawnflags & TRAIN_MOVEONTRIGGER || self.wait < 0)
-		self.cnt = TRAIN_NEXT_CONTINUE;
+		self.plat2GoTo = TRAIN_NEXT_CONTINUE;
 	else if (self.spawnflags & TRAIN_STOPONTRIGGER)
-		self.cnt = TRAIN_NEXT_STOP;
+		self.plat2GoTo = TRAIN_NEXT_STOP;
 }
 
 // path_corner has been reached, so decide what to do next
@@ -302,7 +302,7 @@ void() train_wait = {
 	self.think = train_next;
 
 	// train is moving normally and path_corner has a wait set, so pause for that time.
-	if (self.wait > 0 && self.cnt == TRAIN_NEXT_WAIT && !(self.spawnflags & TRAIN_RETRIGGER)) {
+	if (self.wait > 0 && self.plat2GoTo == TRAIN_NEXT_WAIT && !(self.spawnflags & TRAIN_RETRIGGER)) {
 		// state: stopped
 		self.state = 0;
 		if (self.classname == "misc_modeltrain") SUB_CallAsSelf(self.animcontroller.think, self.animcontroller);
@@ -314,7 +314,7 @@ void() train_wait = {
 	}
 	// train is moving normally and path_corner has no wait time,
 	// or has been forced to move instantly through a triggering.
-	else if (self.cnt != TRAIN_NEXT_STOP && !self.wait && !(self.spawnflags & TRAIN_RETRIGGER)) {
+	else if (self.plat2GoTo != TRAIN_NEXT_STOP && !self.wait && !(self.spawnflags & TRAIN_RETRIGGER)) {
 
 		//play "passing by" sound, if any. If path_corner has a custom one, play that instead
 		if (self.enemy.noise2 != "") sound(self, CHAN_WEAPON, self.enemy.noise2, 1, ATTN_NORM);
@@ -367,7 +367,7 @@ void() train_next = {
 	
 	sound(self, CHAN_VOICE, self.noise1, 1, ATTN_NORM);
 	
-	if(!(!self.wait && self.cnt == TRAIN_NEXT_CONTINUE)) self.cnt = TRAIN_NEXT_WAIT;
+	if(!(!self.wait && self.plat2GoTo == TRAIN_NEXT_CONTINUE)) self.plat2GoTo = TRAIN_NEXT_WAIT;
 
 	//store up any premature triggerings until current movement is finished
 	self.use = train_moving_use; 
@@ -503,7 +503,7 @@ void() func_train =
 	if (self.noise2 != "") precache_sound(self.noise2);
 
 
-	self.cnt = TRAIN_NEXT_WAIT;
+	self.plat2GoTo = TRAIN_NEXT_WAIT;
 	
 	if (self.spawnflags & TRAIN_NONSOLID) {
 		self.solid = SOLID_NOT;

--- a/plats.qc
+++ b/plats.qc
@@ -401,7 +401,7 @@ void() train_next = {
 
 	if (!self.state) {
 		self.state = 1;
-		if (self.classname == "misc_modeltrain" && self.style != TRAIN_STYLE_SINGLEANIM)
+		if (self.classname == "misc_modeltrain" && self.launchtime != TRAIN_STYLE_SINGLEANIM)
 			SUB_CallAsSelf(self.animcontroller.think, self.animcontroller);
 	}
 	
@@ -469,7 +469,7 @@ void() func_train =
 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
 		return;
 
-	if (self.takedamage == DAMAGE_YES)
+	if (self.spawnflags == /*Breakable*/128)
 		func_breakable();
 	
 	if (!self.speed)
@@ -481,8 +481,6 @@ void() func_train =
 
 	if(self.spawnflags & TRAIN_STOPONTRIGGER && self.spawnflags & TRAIN_MOVEONTRIGGER)
 		objerror("func_train: Stop and move on trigger set at the same time");
-
-
 
 	if (self.sounds == 1) {
 		if (self.noise == "") self.noise = ("plats/train2.wav");
@@ -497,14 +495,10 @@ void() func_train =
 		if (self.noise1 == "") self.noise1 = ("misc/null.wav");
 	}
 
-	// backwards compatibility with previous version
-	if (self.noise3 != "") self.noise = self.noise3;
-	if (self.noise4 != "") self.noise1 = self.noise4;
-
 	precache_sound(self.noise);
 	precache_sound(self.noise1);
 	if (self.noise2 != "") precache_sound(self.noise2);
-
+	if (self.noise3 != "") precache_sound(self.noise3); //Breaking sound (applicable to breakable trains)
 
 	self.plat2GoTo = TRAIN_NEXT_WAIT;
 	
@@ -651,7 +645,7 @@ void() misc_modeltrain = {
 	if (self.first_frame2 && !self.last_frame2) self.last_frame2 = self.first_frame2;
 	else if (!self.first_frame2 && self.last_frame2) self.first_frame2 = self.last_frame2;
 
-	if (!self.first_frame2) self.style = TRAIN_STYLE_SINGLEANIM;
+	if (!self.first_frame2) self.launchtime = TRAIN_STYLE_SINGLEANIM;
 
 	if (!self.animtype) self.animtype = TRAIN_ANIMTYPE_FORWARD;
 	if (!self.animtype2) self.animtype2 = self.animtype;

--- a/rubicon2.qc
+++ b/rubicon2.qc
@@ -141,7 +141,7 @@ void() make_breakable_templates_debris = {
 			new.ltime = time;
 			new.nextthink = time + 10 + random()*10;
 			new.flags = 0;
-			new.spawnflags = self.spawnflags;
+			new.spawnflags = self.visitflag;
 			new.skin = self.style;
 			new.snd_hit = self.snd_hit;
 			new.dmg_take = self.dmg_take;
@@ -171,7 +171,7 @@ void() make_breakable_templates_debris = {
 			new.ltime = time;
 			new.nextthink = time + 10 + random()*10;
 			new.flags = 0;
-			new.spawnflags = self.spawnflags;
+			new.spawnflags = self.visitflag;
 			new.skin = self.style;
 			new.snd_hit = self.snd_hit;
 			new.dmg_take = self.dmg_take;
@@ -201,7 +201,7 @@ void() make_breakable_templates_debris = {
 			new.ltime = time;
 			new.nextthink = time + 10 + random()*10;
 			new.flags = 0;
-			new.spawnflags = self.spawnflags;
+			new.spawnflags = self.visitflag;
 			new.skin = self.style;
 			new.snd_hit = self.snd_hit;
 			new.dmg_take = self.dmg_take;
@@ -231,7 +231,7 @@ void() make_breakable_templates_debris = {
 			new.ltime = time;
 			new.nextthink = time + 10 + random()*10;
 			new.flags = 0;
-			new.spawnflags = self.spawnflags;
+			new.spawnflags = self.visitflag;
 			new.skin = self.style;
 			new.snd_hit = self.snd_hit;
 			new.dmg_take = self.dmg_take;
@@ -261,7 +261,7 @@ void() make_breakable_templates_debris = {
 			new.ltime = time;
 			new.nextthink = time + 10 + random()*10;
 			new.flags = 0;
-			new.spawnflags = self.spawnflags;
+			new.spawnflags = self.visitflag;
 			new.skin = self.style;
 			new.snd_hit = self.snd_hit;
 			new.dmg_take = self.dmg_take;
@@ -306,7 +306,7 @@ void() make_breakable_debris = {
 		new.ltime = time;
 		new.nextthink = time + 10 + random()*10;
 		new.flags = 0;
-		new.spawnflags = self.spawnflags;
+		new.spawnflags = self.visitflag;
 		new.skin = self.style;
 		new.snd_hit = self.snd_hit;
 		new.dmg_take = self.dmg_take;
@@ -335,7 +335,8 @@ void () func_breakable_die = {
 		// ent.ltime = time;
 		ent.nextthink = time + 60;
 
-		sound(ent, CHAN_AUTO, self.noise1, 1, ATTN_NORM);
+		sound(ent, CHAN_AUTO, self.noise3, 1, ATTN_NORM);
+		sound(self, CHAN_VOICE, "misc/null.wav", 1, ATTN_NORM); //Stop the looping moving sound of the train (if in a breakable train context)
 		// remove (self);
 	}
 
@@ -344,8 +345,8 @@ void () func_breakable_die = {
 	// floating in mid-air after this entity is removed -- iw
 	SUB_DislodgeRestingEntities ();
 
-	if (self.spawnflags & BREAK_EXPLODE) {
-		if (self.spawnflags & BREAK_CUSTOM) {
+	if (self.visitflag & BREAK_EXPLODE) {
+		if (self.visitflag & BREAK_CUSTOM) {
 			make_breakable_templates_debris ();
 		} else {
 			make_breakable_debris ();
@@ -354,10 +355,10 @@ void () func_breakable_die = {
 		// sound(self, CHAN_VOICE, self.noise2, 1, ATTN_NORM); this is broken as of 1.1.0 no custom explosion sound for now -- dumptruck_ds
 		remove (self);
 	} else {
-		self.origin = ((self.absmin + self.absmax) * 0.5);
+		if(self.origin == '0 0 0') self.origin = ((self.absmin + self.absmax) * 0.5);
 		setorigin (self, self.origin);
 		DropStuff();
-		if (self.spawnflags & BREAK_CUSTOM) {
+		if (self.visitflag & BREAK_CUSTOM) {
 			if (self.switchshadstyle) lightstyle(self.switchshadstyle, "m");
 			make_breakable_templates_debris ();
 			remove (self);
@@ -470,58 +471,75 @@ void () func_breakable = {
 	precache_sound ("blob/hit1.wav");
 	if (self.snd_hit) precache_sound (self.snd_hit);
 
-	if (self.noise1 != "") precache_sound(self.noise1);
-// adding new default sounds for "simple" breakables in 1.2.0 -- dumptruck_ds
-// here's genreic metal breaking
-	if (self.style == 0 || self.style == 11 || self.style == 12 || self.style == 17 || self.style == 18 || self.style == 19
-		|| self.style == 24 || self.style == 31)
-		if !(self.noise1)
+	if(self.spawnflags != /*Breakable*/128)
 	{
-		precache_sound("break/metal2.wav");
-		self.noise1 = "break/metal2.wav";
+		//Regular context: NOT in a breakable train context
+		//self.noise3 and self.visitflag are therefore not set at the train level
+		self.visitflag = self.spawnflags;
+		self.noise3 = self.noise1;
 	}
-	if (self.style == 3 || self.style == 4 || self.style == 5)
-		if !(self.noise1)
-	{
-		precache_sound("break/wood1.wav");
-		precache_sound("break/wood2.wav");
-		if (random() > 0.6) // wood only randomized
-		self.noise1 = "break/wood1.wav";
-		else
-		self.noise1 = "break/wood2.wav";
-	}
-	// glass sounds -- this is more of a shattering sound anyway
-	if (self.style == 6 || self.style == 7 || self.style == 8 || self.style == 9 || self.style == 10)
-		if !(self.noise1)
-	{
-		precache_sound("break/metal1.wav");
-		self.noise1 = "break/metal1.wav";
-	}
-	if (self.style == 1 || self.style == 2 || self.style == 13 || self.style == 14
-		|| self.style == 15 || self.style == 16 || self.style == 20 || self.style == 21
-		|| self.style == 22 || self.style == 23)
-		if !(self.noise1)
-	{
-		precache_sound("break/stones1.wav");
-		precache_sound("break/bricks1.wav");
-		if (random() > 0.6) // wood only randomized
-		self.noise1 = "break/bricks1.wav";
-		else
-		self.noise1 = "break/stones1.wav";
-	}
-	if (self.style == 25 || self.style == 26 || self.style == 27 || self.style == 28 || self.style == 29 || self.style == 30)
-		if !(self.noise1)
-	{
-		precache_sound("break/stones1.wav");
-		precache_sound("break/bricks1.wav");
-		if (random() > 0.6) // wood only randomized
-		self.noise1 = "break/stones1.wav";
-		else
-		self.noise1 = "break/bricks1.wav";
-	}
-	// else
-	// 	(self.noise1 = "blob/hit1.wav");
 
+	if (self.noise3 == "")
+	{
+		switch(self.style)
+		{
+			case 0:
+			case 11:
+			case 12:
+			case 17:
+			case 18:
+			case 19:
+			case 24:
+			case 31:
+				self.noise3 = "break/metal2.wav";
+				break;
+			
+			case 3:
+			case 4:
+			case 5:
+				if (random() > 0.6) // wood only randomized
+					self.noise3 = "break/wood1.wav";
+				else
+					self.noise3 = "break/wood2.wav";
+				break;
+				
+			case 6:
+			case 7:
+			case 8:
+			case 9:
+			case 10:
+				self.noise3 = "break/metal1.wav";
+
+			case 1:
+			case 2:
+			case 13:
+			case 14:
+			case 15:
+			case 16:
+			case 20:
+			case 21:
+			case 22:
+			case 23:
+			case 25:
+			case 26:
+			case 27:
+			case 28:
+			case 29:
+			case 30:
+				if (random() > 0.5) // wood only randomized
+					self.noise3 = "break/bricks1.wav";
+				else
+					self.noise3 = "break/stones1.wav";
+				break;
+
+			default:
+				self.noise3 = "blob/hit1.wav";
+				break;
+		}
+	}
+	precache_sound(self.noise3);
+	precache_sound("misc/null.wav"); //Used to stop the looping moving sound of the train (if in a breakable train context)
+	
 	if (!self.health)
 		self.health = 20;
 	if (!self.cnt)

--- a/rubicon2.qc
+++ b/rubicon2.qc
@@ -283,9 +283,16 @@ void() make_breakable_debris = {
 
 		new = spawn();
 		new.alpha = self.alpha;
-		new.origin_x = (self.maxs_x - self.mins_x)*random() + self.mins_x;
-		new.origin_y = (self.maxs_y - self.mins_y)*random() + self.mins_y;
-		new.origin_z = (self.maxs_z - self.mins_z)*random() + self.mins_z;
+		if(self.origin != '0 0 0')
+		{
+			new.origin = self.origin;
+		}
+		else
+		{
+			new.origin_x = (self.maxs_x - self.mins_x)*random() + self.mins_x;
+			new.origin_y = (self.maxs_y - self.mins_y)*random() + self.mins_y;
+			new.origin_z = (self.maxs_z - self.mins_z)*random() + self.mins_z;
+		}
 		// setmodel (new, "progs/debris.mdl"); this was originally just an mdl from Rubicon2, now you set custom model via spawnflag or use the builtin from Rubicon2 -- dumptruck_ds
 		setmodel (new, self.mdl_debris); //dumptruck_ds
 		setsize (new, '0 0 0', '0 0 0');


### PR DESCRIPTION
Subtle implementation changes now allow trains to take damage and explode the same way func_breakable does.
* The use of the .cnt property for internal plumber work is changed for .plat2GoTo, so that .cnt retrieves its functionality for beakables (number of debris models).
* The point of explosion now follows the train's origin