### PR TITLE
Monster now fire the path_corner's targets when reaching it

### DIFF
--- a/ai.qc
+++ b/ai.qc
@@ -111,7 +111,7 @@ moving towards it, change the next destination and continue.
 */
 void() t_movetarget =
 {
-local entity	temp;
+local entity	temp, temp2;
 
 	if (other.movetarget != self)
 		return;
@@ -119,6 +119,11 @@ local entity	temp;
 	if (other.enemy)
 		return;		// fighting, not following a path
 
+	//Monster fires the path_corner's targets when reaching it
+	temp2 = activator;
+	SUB_UseTargets();
+	activator = temp2;
+	
 	temp = self;
 	self = other;
 	other = temp;

--- a/ai.qc
+++ b/ai.qc
@@ -121,6 +121,7 @@ local entity	temp, temp2;
 
 	//Monster fires the path_corner's targets when reaching it
 	temp2 = activator;
+	activator = other;
 	SUB_UseTargets();
 	activator = temp2;
 	


### PR DESCRIPTION
As the title suggests... ;-)
Meant for patrolling monsters. Possible use case: the monster randomly decides what their next path_corner will be...