### PR TITLE
Monster drops custom key upon death

### DIFF
--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -709,6 +709,7 @@ The behavior of an item_key_custom should be as the player expects (based on the
 		4 : "Drop an Armor Shard upon death"
 		5 : "Drop a Health Vial & Armor Shard"
 		6 : "Random combination of 3 Vials and/or Shards"
+		7 : "Drop a custom key upon death (must exist somewhere else in the level as trigger spawned and be targeted with a target->targetname relationship)"
 	]
 ]
 

--- a/monsters.qc
+++ b/monsters.qc
@@ -214,6 +214,19 @@ void() monster_death_use =
 	{
 		activator = self.enemy;
 	}
+	if (self.drop_item == 7) //Drop a custom key upon death
+	{
+		entity k = world;
+		do
+		{
+			k = find(k,targetname,self.target);
+			if(k.classname=="item_key_custom")
+			{
+				k.origin = self.origin + '0 0 24';
+				break;
+			}
+		} while(k);
+	}
 	SUB_UseTargets ();
 };
 


### PR DESCRIPTION
A new drop_item value of 7 now allows a monster to drop a custom key upon death.
The monster must point to the trigger-spawned key thanks to a target/targetname relationship.