### PR TITLE
trigger_random_time + train fixes

### DIFF
--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -3907,4 +3907,8 @@ Toggles ON/OFF when used
 [
 	delay(integer) : "Minimum time between events" : 2
 	wait(integer) : "Maximum time between events" : 20
+	spawnflags(flags) =
+	[
+		1: "Once" : 0 : "Acts like a trigger_relay with a random delay and fires its targets just once; no subsequent random calls afterwards unless retriggered"
+	]
 ]

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -2371,11 +2371,13 @@ Spawnflags:
 	[
 		1 : "One way"
 		2 : "Back and forth"
+		3 : "Once"
 	]
 	animtype2(choices) : "Animation type (moving)" : 1 =
 	[
 		1 : "One way"
 		2 : "Back and forth"
+		3 : "Once"
 	]
 	multiplier(integer) : "Turning speed" : 1 : "Turning speed multiplier. Set to -1 to turn instantly"
 	noise1(string) : "Custom moving loop sound (if set, overrides 'sounds')"
@@ -2450,11 +2452,13 @@ Check each field's description for more details.
 	[
 		1 : "One way"
 		2 : "Back and forth"
+		3 : "Once"
 	]
 	animtype2(choices) : "Animation type (moving)" : 1 =
 	[
 		1 : "One way"
 		2 : "Back and forth"
+		3 : "Once"
 	]
 	multiplier(integer) : "Turning speed" : 1 : "Turning speed multiplier. Set to -1 to turn instantly"
 	noise(string) : "Custom stopping sound for this point"
@@ -3894,3 +3898,13 @@ Example: 3 targets of impulse respectively 3, 2 and 1 --> Total cumulated impuls
 ]
 
 @SolidClass base(Appearflags, Targetname) = func_playerclip : "A bbox entity which is solid for the player only" []
+
+@PointClass base(Appearflags, Target, Targetname) size (16 16 16) color(192 0 192) = trigger_random_time : "Fire targets at random intervals
+
+Starts off if a targetname is specified
+Toggles ON/OFF when used
+"
+[
+	delay(integer) : "Minimum time between events" : 2
+	wait(integer) : "Maximum time between events" : 20
+]

--- a/plats.qc
+++ b/plats.qc
@@ -372,6 +372,8 @@ void() train_next = {
 	//store up any premature triggerings until current movement is finished
 	self.use = train_moving_use; 
 
+	float waitwascalled =0;
+	
 	if (self.classname == "misc_modeltrain") {
 		if (!(self.spawnflags & TRAIN_NOROTATE)) {
 			void() angleMoveDone = SUB_Null;
@@ -392,7 +394,10 @@ void() train_next = {
 					destang_z = self.angles_z;
 				}
 				if (self.multiplier > 0)
+				{
+					if(angleMoveDone == train_wait) waitwascalled = 1;
 					SUB_CalcAngleMoveController(destang, self.speed2*self.multiplier, angleMoveDone, self.rotatecontroller);
+				}
 				else
 					self.angles = destang;
 			}
@@ -406,7 +411,10 @@ void() train_next = {
 	}
 	
 	if (targ.origin == self.origin) //Rotation done, no translation
+	{
+		if(!waitwascalled) train_wait();
 		return;
+	}
 	
 	// if the TRAIN_CUSTOMALIGN flag is checked then the train should align
 	// with its path_corners based on the location of an "origin" brush added
@@ -542,7 +550,7 @@ void() animcontroller_think = {
 
 	// train just went from stopped to moving or vice-versa,
 	// and have both animations set
-	if (self.state != tr.state && tr.style != TRAIN_STYLE_SINGLEANIM) {
+	if (self.state != tr.state && tr.launchtime != TRAIN_STYLE_SINGLEANIM) {
 		if (tr.state) { // just started moving
 			tr.frame = zeroconvert(tr.first_frame2);
 		}
@@ -554,7 +562,7 @@ void() animcontroller_think = {
 	}
 	
 	else {
-		if (self.state && tr.style != TRAIN_STYLE_SINGLEANIM) { // moving train animation, if set
+		if (self.state && tr.launchtime != TRAIN_STYLE_SINGLEANIM) { // moving train animation, if set
 			first = zeroconvert(tr.first_frame2);
 			last = zeroconvert(tr.last_frame2);
 			atype = tr.animtype2;
@@ -573,13 +581,15 @@ void() animcontroller_think = {
 		
 		nextframe = tr.frame + step;
 
-		if (atype == TRAIN_ANIMTYPE_BACKFORTH){
-			if (dir > 0 && (nextframe > last || nextframe < first) ||
-				dir < 0 && (nextframe > first || nextframe < last)
-			) {
+		if (dir > 0 && (nextframe > last || nextframe < first) ||
+			dir < 0 && (nextframe > first || nextframe < last)
+		) {
+			if (atype == TRAIN_ANIMTYPE_BACKFORTH){
 				nextframe = tr.frame - step;
 				tr.distance = tr.distance * (-1);
 			}
+			else if (atype == /*Animate once*/3)
+				nextframe = tr.frame;
 		}
 
 		if (dir > 0) nextframe = wrap(nextframe, first, last);
@@ -590,7 +600,7 @@ void() animcontroller_think = {
 	}
 
 	self.think = animcontroller_think;
-	if (self.state || tr.style == TRAIN_STYLE_SINGLEANIM) self.nextthink = time + tr.frtime;
+	if (self.state || tr.launchtime == TRAIN_STYLE_SINGLEANIM) self.nextthink = time + tr.frtime;
 	else self.nextthink = time + tr.frtime2;
 };
 

--- a/triggers.qc
+++ b/triggers.qc
@@ -2260,11 +2260,21 @@ void() random_time_think =
  	if (self.estate != STATE_ACTIVE)
 		return;
 	
-	float t = self.wait * random();
-	if (t < self.delay)
-		t = self.delay;
-	self.nextthink = time + t;
 	SUB_UseTargets();
+
+	if (self.spawnflags&/*Once*/1)
+	{
+		//Reset to inactive
+		random_time_use();
+	}
+	else
+	{
+		//Prepare the next random call
+		float t = self.wait * random();
+		if (t < self.delay)
+			t = self.delay;
+		self.nextthink = time + t;
+	}
 };
 
 void() random_time_use =
@@ -2273,7 +2283,12 @@ void() random_time_use =
 	{
 		self.estate = STATE_ACTIVE;
 		self.think = random_time_think;
-		self.think();
+		
+		//Call think at a random time
+		float t = self.wait * random();
+		if (t < self.delay)
+			t = self.delay;
+		self.nextthink = time + t;
 	}
 	else
 	{

--- a/triggers.qc
+++ b/triggers.qc
@@ -2249,3 +2249,53 @@ void() trigger_enterleave =
     self.touch = trigger_enterleave_enter;
     self.wait = 0; // 0 is left, 1 is touched
 };
+
+/*QUAKED trigger_random_time
+Fires its targets every now and then at random intervals
+"delay" minimum time between firing targets (default 2)
+"wait"  maximum time between firing targets (default 20)
+*/
+void() random_time_think =
+{
+ 	if (self.estate != STATE_ACTIVE)
+		return;
+	
+	float t = self.wait * random();
+	if (t < self.delay)
+		t = self.delay;
+	self.nextthink = time + t;
+	SUB_UseTargets();
+};
+
+void() random_time_use =
+{
+	if (self.estate != STATE_ACTIVE)
+	{
+		self.estate = STATE_ACTIVE;
+		self.think = random_time_think;
+		self.think();
+	}
+	else
+	{
+		self.estate = STATE_INACTIVE;
+		self.think = SUB_Null;
+	}
+};
+
+void() trigger_random_time =
+{
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
+	if (self.wait == 0)
+		self.wait = 20;
+	if (self.delay == 0)
+		self.delay = 2;
+
+	self.think = random_time_think;
+	self.use = random_time_use;
+	if(self.targetname)
+		self.estate = STATE_INACTIVE;
+	else
+		self.nextthink = time + 0.2;
+};


### PR DESCRIPTION
* [Evol] The new trigger_random_time entity allows to trigger things at random time intervals
* [Evol] Misc_modeltrains now support a new animation mode: animate just once (no loop)
* [Fix] A few occurrences of .style had not been replaced by .launchtime (to avoid any conflict with the breakable train's style)