### PR TITLE
Turret mode for everyone! 🤘🥳

### DIFF
--- a/boss.qc
+++ b/boss.qc
@@ -284,9 +284,6 @@ void() monster_boss =
 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
 		return;
 
-	if (self.spawnflags & I_AM_TURRET)
-		objerror("Incompatible spawnflag: TURRET_MODE\n");
-
 	if (deathmatch)
 	{
 		remove(self);

--- a/boss2.qc
+++ b/boss2.qc
@@ -458,9 +458,6 @@ void() monster_boss2 =
 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
 		return;
 
-	if (self.spawnflags & I_AM_TURRET)
-		objerror("Incompatible spawnflag: TURRET_MODE\n");
-
 	if (deathmatch)
 	{
 		remove(self);

--- a/demon.qc
+++ b/demon.qc
@@ -269,9 +269,6 @@ void() monster_demon1 =
 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
 		return;
 
-	if (self.spawnflags & I_AM_TURRET)
-		objerror("Incompatible spawnflag: TURRET_MODE\n");
-
 	if (deathmatch)
 	{
 		remove(self);

--- a/dog.qc
+++ b/dog.qc
@@ -428,9 +428,6 @@ void() monster_dog =
 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
 		return;
 
-	if (self.spawnflags & I_AM_TURRET)
-		objerror("Incompatible spawnflag: TURRET_MODE\n");
-
 	if (deathmatch)
 	{
 		remove(self);

--- a/fish.qc
+++ b/fish.qc
@@ -261,9 +261,6 @@ void() monster_fish =
 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
 		return;
 
-	if (self.spawnflags & I_AM_TURRET)
-		objerror("Incompatible spawnflag: TURRET_MODE\n");
-
 	if (deathmatch)
 	{
 		remove(self);

--- a/knight.qc
+++ b/knight.qc
@@ -327,9 +327,6 @@ void() monster_knight =
 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
 		return;
 
-	if (self.spawnflags & I_AM_TURRET)
-		objerror("Incompatible spawnflag: TURRET_MODE\n");
-
 	if (deathmatch)
 	{
 		remove(self);

--- a/oldone.qc
+++ b/oldone.qc
@@ -259,9 +259,6 @@ void() monster_oldone =
 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
 		return;
 
-	if (self.spawnflags & I_AM_TURRET)
-		objerror("Incompatible spawnflag: TURRET_MODE\n");
-
 	if (deathmatch)
 	{
 		remove(self);

--- a/oldone2.qc
+++ b/oldone2.qc
@@ -314,9 +314,6 @@ void() monster_oldone2 =
 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
 		return;
 
-	if (self.spawnflags & I_AM_TURRET)
-		objerror("Incompatible spawnflag: TURRET_MODE\n");
-
 	if (deathmatch)
 	{
 		remove(self);

--- a/spawn.qc
+++ b/spawn.qc
@@ -249,9 +249,6 @@ void() monster_tarbaby =
 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
 		return;
 
-	if (self.spawnflags & I_AM_TURRET)
-		objerror("Incompatible spawnflag: TURRET_MODE\n");
-
 	if (deathmatch)
 	{
 		remove(self);

--- a/wizard.qc
+++ b/wizard.qc
@@ -491,9 +491,6 @@ void() monster_wizard =
 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
 		return;
 
-	if (self.spawnflags & I_AM_TURRET)
-		objerror("Incompatible spawnflag: TURRET_MODE\n");
-
 	if (deathmatch)
 	{
 		remove(self);


### PR DESCRIPTION
Melee monsters were not allowed to support the 'Turret mode' spawnflag, which is a shameful discrimination towards those poor guys... and towards wicked modders wanted to trigger events based on player being seen from a fixed point without necessarily leading to monster projectiles being thrown at the player's face.