### PR TITLE
Monsters drop whatever

### DIFF
--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -712,7 +712,7 @@ The behavior of an item_key_custom should be as the player expects (based on the
 		4 : "Drop an Armor Shard upon death"
 		5 : "Drop a Health Vial & Armor Shard"
 		6 : "Random combination of 3 Vials and/or Shards"
-		7 : "Drop a custom key upon death (must exist somewhere else in the level as trigger spawned and be targeted with a target->targetname relationship)"
+		7 : "Drop whatever (custom key, weapon, quad, ammo, rune, health, etc.) upon death (must exist somewhere else in the level as trigger spawned and be targeted with a target->targetname relationship)"
 	]
 ]
 

--- a/monsters.qc
+++ b/monsters.qc
@@ -214,18 +214,10 @@ void() monster_death_use =
 	{
 		activator = self.enemy;
 	}
-	if (self.drop_item == 7) //Drop a custom key upon death
+	if (self.drop_item == 7) //Drop something (custom key, weapon, ammo, quad, etc.) upon death
 	{
-		entity k = world;
-		do
-		{
-			k = find(k,targetname,self.target);
-			if(k.classname=="item_key_custom")
-			{
-				k.origin = self.origin + '0 0 24';
-				break;
-			}
-		} while(k);
+		entity k = find(world,targetname,self.target);
+		if(k) k.origin = self.origin + '0 0 24';
 	}
 	SUB_UseTargets ();
 };


### PR DESCRIPTION
Monsters can now drop whatever upon death: custom key, weapon, quad, ammo, rune, health, etc.

The thing in question must be a an existing trigger-spawnable entity somewhere in the map, referenced by a target->targetname relationship.