### PR TITLE
Impulse 9 gives keys no more

### DIFF
--- a/weapons.qc
+++ b/weapons.qc
@@ -1475,7 +1475,7 @@ void() CheatCommand =
 		IT_SUPER_NAILGUN |
 		IT_GRENADE_LAUNCHER |
 		IT_ROCKET_LAUNCHER;
-	GiveAllKeys (self);  // support for item_key_custom -- iw
+	//GiveAllKeys (self);  // support for item_key_custom -- iw
 
 	self.ammo_cells = 100;
 	self.items = self.items | IT_LIGHTNING;

--- a/weapons.qc
+++ b/weapons.qc
@@ -1681,6 +1681,8 @@ void() ImpulseCommands =
 		ServerflagsCommand ();
 	if (self.impulse == 12)
 		CycleWeaponReverseCommand ();
+	if (self.impulse == 13)
+		GiveAllKeys (self);
 
 	if (self.impulse == 255)
 		QuadCheat ();


### PR DESCRIPTION
While the `impulse 9` command is a useful cheat code for not bothering with weapons/ammo, having it give all the keys as well is of another nature entirely and can really break the map (when the act of grabbing a key triggers events, which is a pretty common pattern).
If "thanks" to `impulse 9` the key cannot be grabbed anymore, the events are not triggered, possibly resulting in a softlock.
Removing the "all keys granted" effect keeps the players the satisfaction of a true exploration and puzzle items chase throughout the map, while still taking advantage of full armory+ammo.
And if really they want to pass closed doors, pretty sure they know the `noclip` cheat code as well.