### PR TITLE
Fire targets when no key

### DIFF
--- a/doors.qc
+++ b/doors.qc
@@ -296,7 +296,7 @@ void() door_touch =
 	if (!keylock_has_key_set ())
 		return;
 
-	keylock_try_to_unlock (other, "", self.owner.message2, door_unlock);
+	keylock_try_to_unlock (other, "", self.owner.message2, door_unlock, SUB_UsePain2);
 };
 
 

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -333,6 +333,7 @@ NOTE when a trigger_teleport has a targetname it must be triggered to operate, s
 @PointClass base(Appearflags, Fog) = info_intermission : "Intermission camera"
 [
 	mangle(string) : "Camera angle (Pitch Yaw Roll)"
+	targetname(string) : "Use to force this intermission camera by making it the target of a trigger_changelevel"
 ]
 
 @PointClass = info_intermissiontext : "Intermission Text
@@ -2579,6 +2580,7 @@ Check each field's description for more details.
 		8: "Start Off" : 0
 		16: "Use info_player_start2" : 0
 	]
+	target(string) : "Specific intermission camera to use (works only if matching an info_intermission's targetname), otherwise a regular target to fire"
 ]
 
 @SolidClass base(Trigger) = trigger_once : "Trigger: Activate once"

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -1957,6 +1957,7 @@ Originally unused in the game. Plays the sound of thunder at a random interval. 
 	dmg(integer) : "Damage inflicted when blocked" : 2
 	message(string) : "Message if touched"
 	message2(string) : "Message when key used"
+	pain_target(string) : "Target to fire when not having key"
 	health(integer) : "Health (shootable)" : 0
 	cnt(choices) : "Leave key in player's inventory?" : 0 =
 	[
@@ -2634,6 +2635,7 @@ NOTE: You must specify either the silver or gold key by setting the relevant spa
 		8 : "Silver Key Required" : 0
 		16 : "Gold Key Required" : 0
 	]
+	pain_target(string) : "Target to fire when not having key"
 ]
 
 @SolidClass base(Trigger) = trigger_multiple : "Trigger: Activate multiple"

--- a/hiptrig.qc
+++ b/hiptrig.qc
@@ -44,7 +44,7 @@ void() keytrigger_use =
 		return;
 
 	self.attack_finished = time + 2;
-	keylock_try_to_unlock (activator, self.message, self.message2, keytrigger_unlock);
+	keylock_try_to_unlock (activator, self.message, self.message2, keytrigger_unlock, SUB_UsePain2);
 };
 
 void() keytrigger_touch =

--- a/intermission.qc
+++ b/intermission.qc
@@ -116,6 +116,11 @@ entity() FindIntermission =
 	local	entity spot;
 	local	float cyc;
 
+	
+	spot = find (world, targetname, self.target);
+	if (spot != world && spot.classname == "info_intermission")
+		return spot;
+	
 // look for info_intermission first
 	spot = find (world, classname, "info_intermission");
 	if (spot)

--- a/keylock.qc
+++ b/keylock.qc
@@ -186,7 +186,7 @@ of the original game.  -- iw
 ================
 */
 void(entity client, string failure_message, string success_message,
-		void() success_func) keylock_try_to_unlock =
+		void() success_func, void() failure_func) keylock_try_to_unlock =
 {
 	local string s = "";
 
@@ -201,6 +201,7 @@ void(entity client, string failure_message, string success_message,
 				centerprint2 (client, "You need the ", self.netname);
 			sound (self, CHAN_VOICE, self.noise3, 1, ATTN_NORM);
 		}
+		failure_func();
 		return;
 	}
 

--- a/subs.qc
+++ b/subs.qc
@@ -624,6 +624,17 @@ void() SUB_UsePain =
 	self.pain_target = "";  //dumptruck_ds via Discord - thanks Spike, Snaut and QueenJazz
 };
 
+void() SUB_UsePain2 =
+{
+	if (self.pain_target != "")
+	{
+		SUB_UseSpecificTarget (self.pain_target, targetname);
+		SUB_UseSpecificTarget (self.pain_target, targetname2);
+		SUB_UseSpecificTarget (self.pain_target, targetname3);
+		SUB_UseSpecificTarget (self.pain_target, targetname4);
+	}
+};
+
 /*
 
 in nightmare mode, all attack_finished times become 0


### PR DESCRIPTION
Similarly to what already exists for other entities (e.g. trigger_filter) doors and trigger_usekey now support the pain_target property to fires targets when NOT having the required key.
Having success targets and failure targets as well for the same door/trigger might be achieved otherwise at the price of painful and awkward quirks. This QOL addition makes things more natural, easy, and consistent with how RM entities use to work.