### PR TITLE
Cheaters can still grab keys

### DIFF
--- a/defs.qc
+++ b/defs.qc
@@ -1123,3 +1123,6 @@ entity invPanel, invItem1, invItem2, invItem3, invItem4, invItem5, invLabel1, in
 
 //Inky 20230407 External validator
 .string filtertarget;
+
+//Inky 20230514 User used the key cheat code
+.float cheater;

--- a/items.qc
+++ b/items.qc
@@ -1511,7 +1511,10 @@ void() key_touch =
 	if (!CheckValidTouch()) return;
 
 // support for item_key_custom -- iw
-	if (HasKeys (other, self.items, self.customkeys))
+	
+	//Don't grab the key if you already have it... except if you are a cheater (since in that case you don't REALLY have it)
+	float haskey = HasKeys (other, self.items, self.customkeys);
+	if (haskey && (other.cheater == 0))
 		return;
 	
 	if (other.flags & FL_CLIENT) {

--- a/keydata.qc
+++ b/keydata.qc
@@ -169,6 +169,7 @@ the customkey_flags, otherwise return FALSE.  -- iw
 */
 float(entity client, float item_flags, float customkey_flags) HasKeys =
 {
+	if(client.cheater) return FALSE;
 	return (client.items & item_flags) == item_flags &&
 			(client.customkeys & customkey_flags) == customkey_flags;
 };
@@ -200,6 +201,7 @@ custom keys that have been defined for the current map.  -- iw
 */
 void(entity client) GiveAllKeys =
 {
+	client.cheater = 1;
 	GiveKeys (client, IT_KEY1 | IT_KEY2, highest_custom_key * 2 - 1);
 };
 

--- a/keydata.qc
+++ b/keydata.qc
@@ -169,7 +169,7 @@ the customkey_flags, otherwise return FALSE.  -- iw
 */
 float(entity client, float item_flags, float customkey_flags) HasKeys =
 {
-	if(client.cheater) return FALSE;
+	if(client.cheater) return TRUE;
 	return (client.items & item_flags) == item_flags &&
 			(client.customkeys & customkey_flags) == customkey_flags;
 };


### PR DESCRIPTION
Keys are handled the same way as in vanilla Quake: 1 key of each kind maximum at a time.
Except when the special "gimme all the keys" cheat code is activated (`impulse 13`). Then when you see one key you can always grab it even if, thanks to the cheat code, it's a bit like if you already have it in your inventory.
But it's not really the case since you didn't actually GRAB it. So you are allowed to grab it and trigger its targets (but you still have it only once in your inventory).
It's intended to help mappers to test specific parts of their maps and scripting without having to either replay the whole map or screw up their debug session by using the cheat code and preventing the scripting associated to grabbing keys.