### PR TITLE
func_hook tracer distance (refined and more flexible implementation)

### DIFF
--- a/client.qc
+++ b/client.qc
@@ -852,12 +852,12 @@ void() CheckGrapple =
 			self.volume = 0;
 		}
 		
-		player_aim = player_offset + (v_forward * trace_ent.distance);
+		player_aim = player_offset + (v_forward * trace_ent.lip);
 		new.origin = player_aim;
 		
 		if(!(trace_ent.spawnflags & /*Non rotating tracer*/4))
 			new.angles[2] = (time * 100) % 360;
-		new.alpha = (dist / 300) - (0.5);
+		new.alpha = (dist / trace_ent.distance) - (0.5);
 		setmodel (new, trace_ent.mdl);
 
 		setsize (new, '0 0 0', '0 0 0');

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -1754,7 +1754,9 @@ Spawnflags:
 	
 	mdl(string) : "Model file for the tracer."
 	
-	distance(integer) : "Distance from the player the tracer model shows up." : 200
+	distance(integer) : "Minimum distance between the player and the func_hook for the tracer model to show up." : 300
+	
+	lip(integer) : "How many units away from the player the tracer model shows up." : 200
 	
 	alpha(integer) : "Transparancy (.1 barely visible - .9 almost opaque)" : 1
 	
@@ -1763,6 +1765,7 @@ Spawnflags:
 		1 : "Aim only" : 0
 		2 : "Player noclip" : 0
 		4 : "Non rotating tracer" : 0
+		8 : "Flicker" : 0
 	]
 ]
 

--- a/rm_mechanics.qc
+++ b/rm_mechanics.qc
@@ -350,7 +350,10 @@ void() func_hook =
 	}
 	
 	if(!self.distance)
-		self.distance = 200;
+		self.distance = 300;
+		
+	if(!self.lip)
+		self.lip = 200;
 		
 	if(!self.mdl)
 		self.mdl = "progs/tracer1.mdl";


### PR DESCRIPTION
How custom distance is handled for func_hook tracer is more satisfactory and flexible.
Now **.distance** is the minimum distance from the func_hook to see the tracer show up (can be reduced in cramped spaces) and **.lip** is how far away from the player the travcer shows up in front of him.
If not set, the default values of 300 and 200 apply respectively.

/!\ CAUTION: this is a breaking change towards the previous implementation, in which

- .distance was playing the role now played by .lip
- the role now played by .distance was not customizable

This feature is most likely used by nobody anyway so the breaking change should impact no one.