### PR TITLE
Fix trigger_enterleave's use of 'activator'

### DIFF
--- a/triggers.qc
+++ b/triggers.qc
@@ -2215,7 +2215,7 @@ void() trigger_enterleave_leave =
 		self.target = "";
 		self.target2 = "";
 		self.killtarget = "";
-		activator = other;
+		activator = self.enemy;
 		SUB_UseTargets();
 		self.target = otarget;
 		self.target2 = otarget2;
@@ -2239,7 +2239,8 @@ void() trigger_enterleave_enter =
 			self.target3 = "";
 			self.target4 = "";
 			self.killtarget2 = "";
-			activator = other;
+			self.enemy = other;
+			activator = self.enemy;
             SUB_UseTargets();
 			self.target3 = otarget3;
 			self.target4 = otarget4;


### PR DESCRIPTION
When someone leaves the volume of a trigger_enterleave, the targets of the latter may be fired with the leaver as 'activator'.
But the memory of who that was had been lost in the meantime and was returned to world.
Now the memory is correctly kept in self.enemy.