### PR TITLE
Fix touch on trigger_usekey

### DIFF
--- a/hiptrig.qc
+++ b/hiptrig.qc
@@ -37,9 +37,6 @@ void() keytrigger_unlock =
 
 void() keytrigger_use =
 {
-  // from Copper -- dumptruck_ds
-  if (!CheckValidTouch()) return;
-
 	if (self.attack_finished > time)
 		return;
 
@@ -49,6 +46,9 @@ void() keytrigger_use =
 
 void() keytrigger_touch =
 {
+	// from Copper -- dumptruck_ds
+	if (!CheckValidTouch()) return;
+
 	activator = other;
 	keytrigger_use();
 };


### PR DESCRIPTION
For some reason, the check for a valid touch was in the use function instead of the touch function. 🤷🏿‍♂️
Guess what? It screwed up when 'using' the trigger instead of 'touching' it...