### PR TITLE
Kill text safely

### DIFF
--- a/subs.qc
+++ b/subs.qc
@@ -389,6 +389,7 @@ void() SUB_UseTargets =
 		while(t != world)
 		{
 			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "m");
+			if(t.enemy != world && t.enemy.suppressCenterPrint == TRUE) t.enemy.suppressCenterPrint = FALSE;
 			remove(t);
 			t = find(t, targetname, self.killtarget);
 		}
@@ -396,6 +397,7 @@ void() SUB_UseTargets =
 		while(t != world)
 		{
 			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "m");
+			if(t.enemy != world && t.enemy.suppressCenterPrint == TRUE) t.enemy.suppressCenterPrint = FALSE;
 			remove(t);
 			t = find(t, targetname2, self.killtarget);
 		}
@@ -403,6 +405,7 @@ void() SUB_UseTargets =
 		while(t != world)
 		{
 			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "m");
+			if(t.enemy != world && t.enemy.suppressCenterPrint == TRUE) t.enemy.suppressCenterPrint = FALSE;
 			remove(t);
 			t = find(t, targetname3, self.killtarget);
 		}
@@ -410,6 +413,7 @@ void() SUB_UseTargets =
 		while(t != world)
 		{
 			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "m");
+			if(t.enemy != world && t.enemy.suppressCenterPrint == TRUE) t.enemy.suppressCenterPrint = FALSE;
 			remove(t);
 			t = find(t, targetname4, self.killtarget);
 		}
@@ -424,6 +428,7 @@ void() SUB_UseTargets =
 		while(t != world)
 		{
 			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "m");
+			if(t.enemy != world && t.enemy.suppressCenterPrint == TRUE) t.enemy.suppressCenterPrint = FALSE;
 			remove(t);
 			t = find(t, targetname, self.killtarget2);
 		}
@@ -431,6 +436,7 @@ void() SUB_UseTargets =
 		while(t != world)
 		{
 			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "m");
+			if(t.enemy != world && t.enemy.suppressCenterPrint == TRUE) t.enemy.suppressCenterPrint = FALSE;
 			remove(t);
 			t = find(t, targetname2, self.killtarget2);
 		}
@@ -438,6 +444,7 @@ void() SUB_UseTargets =
 		while(t != world)
 		{
 			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "m");
+			if(t.enemy != world && t.enemy.suppressCenterPrint == TRUE) t.enemy.suppressCenterPrint = FALSE;
 			remove(t);
 			t = find(t, targetname3, self.killtarget2);
 		}
@@ -445,6 +452,7 @@ void() SUB_UseTargets =
 		while(t != world)
 		{
 			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "m");
+			if(t.enemy != world && t.enemy.suppressCenterPrint == TRUE) t.enemy.suppressCenterPrint = FALSE;
 			remove(t);
 			t = find(t, targetname4, self.killtarget2);
 		}


### PR DESCRIPTION
PD3 text tools (trigger_textstory & target_textstory) have a very specific behavior regarding centerprints: they turn them into more discreet second-class prints at the top left part of the screen. So that their own text keeps the spotlight.
If killtargeted, they don't "give the spotlight back" and subsequent centerprints keep being "downgraded".
It's now fixed: SUB_UseTargets forces things back to normal.