### PR TITLE
New trampoline code

### DIFF
--- a/client.qc
+++ b/client.qc
@@ -1438,6 +1438,8 @@ void() PlayerPostThink =
 			dprint4(self.classname, " (", ftos(framecount), "): Hit the ground, running think\n");
 
 			SUB_CallAsSelf(bouncecontroller_think, self.bouncecontroller);
+			self.jump_flag = 0;
+		}
 	}
 
 // check to see if player landed and play landing sound

--- a/client.qc
+++ b/client.qc
@@ -1422,11 +1422,11 @@ void() PlayerPostThink =
 
 	W_WeaponFrame ();
 	
-// Re:Mobilize: Cushion sounds for trampolines (landing on them without pressing jump)
-
+	// Re:Mobilize: Cushion sounds for trampolines (landing on them without pressing jump)
+	//dprint6(self.classname, " (", ftos(framecount), "): jump flag: ", ftos(self.jump_flag), "\n");
 	if ((self.jump_flag < -100) && (self.flags & FL_ONGROUND) && (self.health > 0)) 
 	{
-		//dprint6(self.classname, " (", ftos(framecount), "): jump flag: ", ftos(self.jump_flag), "\n");
+		
 		//dprint6(self.classname, " (", ftos(framecount), "): cushion entity: ", self.cushion.classname, "\n");
 
 		//dprint5(self.classname, " (", ftos(framecount), "): nextthink: ", ftos(self.bouncecontroller.nextthink));

--- a/client.qc
+++ b/client.qc
@@ -1426,15 +1426,18 @@ void() PlayerPostThink =
 
 	if ((self.jump_flag < -100) && (self.flags & FL_ONGROUND) && (self.health > 0)) 
 	{
-		if (self.cushion) 
+		//dprint6(self.classname, " (", ftos(framecount), "): jump flag: ", ftos(self.jump_flag), "\n");
+		//dprint6(self.classname, " (", ftos(framecount), "): cushion entity: ", self.cushion.classname, "\n");
+
+		//dprint5(self.classname, " (", ftos(framecount), "): nextthink: ", ftos(self.bouncecontroller.nextthink));
+		//dprint3(", time: ", ftos(time), "\n");
+		if (self.cushion)
 		{
 			// checks if the player hit the ground before any scheduled trampoline push happened
 			// if there's one, forces it to happen now
-			if (self.bouncecontroller.nextthink > time) {
-				dprint4(self.classname, " (", ftos(time), "s): Hit the ground before think\n");
-				SUB_CallAsSelf(bouncecontroller_think, self.bouncecontroller);
-			}
-			
+			dprint4(self.classname, " (", ftos(framecount), "): Hit the ground, running think\n");
+
+			SUB_CallAsSelf(bouncecontroller_think, self.bouncecontroller);
 			self.jump_flag = 0;
 		}
 	}

--- a/client.qc
+++ b/client.qc
@@ -1424,60 +1424,20 @@ void() PlayerPostThink =
 	
 // Re:Mobilize: Cushion sounds for trampolines (landing on them without pressing jump)
 
-if ((self.jump_flag < -100) && (self.flags & FL_ONGROUND) && (self.health > 0)) 
-{
+	if ((self.jump_flag < -100) && (self.flags & FL_ONGROUND) && (self.health > 0)) 
+	{
 		if (self.cushion) 
 		{
 			// checks if the player hit the ground before any scheduled trampoline push happened
 			// if there's one, forces it to happen now
-			if (self.bouncecontroller.nextthink <= time) {
-				if (self.cushionnoise!="") {
-					sound (self, CHAN_AUTO, self.cushionnoise, 1, ATTN_NORM);
-				}
-				else if (self.cushionsounds==1)
-				{
-					sound (self, CHAN_AUTO, "misc/cushion2.wav", 1, ATTN_NORM);
-				}
-				else if (self.cushionsounds==2)
-				{
-					sound (self, CHAN_AUTO, "misc/cushion3.wav", 1, ATTN_NORM);
-				}
-				else if (self.cushionsounds==3)
-				{
-					sound (self, CHAN_AUTO, "misc/cushion4.wav", 1, ATTN_NORM);
-				}
-				else if (self.cushionsounds==4)
-				{
-					sound (self, CHAN_AUTO, "misc/cushion5.wav", 1, ATTN_NORM);
-				}
-				else if (self.cushionsounds==5)
-				{
-					sound (self, CHAN_AUTO, "misc/cushion6.wav", 1, ATTN_NORM);
-				}
-				else
-				{
-					sound (self, CHAN_AUTO, "misc/cushion1.wav", 1, ATTN_NORM);
-				}
-							
-				//Fire trampoline targets on cushion landing
-				float ostate = self.state;
-				self.state = ostate | STATE_RM_CUSHIONED;
-				entity oactivator = activator;
-				activator = self;
-				entity oself = self;
-				self = self.cushion;
-				SUB_UseTargets();
-				self = oself;
-				activator = oactivator;
-				self.state = ostate;
-			}
-			else {
-				SUB_CallAsSelf(self.bouncecontroller.think, self.bouncecontroller);
+			if (self.bouncecontroller.nextthink > time) {
+				dprint4(self.classname, " (", ftos(time), "s): Hit the ground before think\n");
+				SUB_CallAsSelf(bouncecontroller_think, self.bouncecontroller);
 			}
 			
 			self.jump_flag = 0;
 		}
-}
+	}
 
 // check to see if player landed and play landing sound
 	if ((self.jump_flag < -300) && (self.flags & FL_ONGROUND) && (self.health > 0))

--- a/client.qc
+++ b/client.qc
@@ -1428,54 +1428,47 @@ if ((self.jump_flag < -100) && (self.flags & FL_ONGROUND) && (self.health > 0))
 {
 		if (self.cushion) 
 		{
-			// checks if the player hit the ground before any scheduled trampoline push happened
-			// if there's one, forces it to happen now
-			if (self.bouncecontroller.nextthink <= time) {
-				if (self.cushionnoise!="") {
-					sound (self, CHAN_AUTO, self.cushionnoise, 1, ATTN_NORM);
-				}
-				else if (self.cushionsounds==1)
-				{
-					sound (self, CHAN_AUTO, "misc/cushion2.wav", 1, ATTN_NORM);
-				}
-				else if (self.cushionsounds==2)
-				{
-					sound (self, CHAN_AUTO, "misc/cushion3.wav", 1, ATTN_NORM);
-				}
-				else if (self.cushionsounds==3)
-				{
-					sound (self, CHAN_AUTO, "misc/cushion4.wav", 1, ATTN_NORM);
-				}
-				else if (self.cushionsounds==4)
-				{
-					sound (self, CHAN_AUTO, "misc/cushion5.wav", 1, ATTN_NORM);
-				}
-				else if (self.cushionsounds==5)
-				{
-					sound (self, CHAN_AUTO, "misc/cushion6.wav", 1, ATTN_NORM);
-				}
-				else
-				{
-					sound (self, CHAN_AUTO, "misc/cushion1.wav", 1, ATTN_NORM);
-				}
-							
-				//Fire trampoline targets on cushion landing
-				float ostate = self.state;
-				self.state = ostate | STATE_RM_CUSHIONED;
-				entity oactivator = activator;
-				activator = self;
-				entity oself = self;
-				self = self.cushion;
-				SUB_UseTargets();
-				self = oself;
-				activator = oactivator;
-				self.state = ostate;
+			if (self.cushionnoise!="") {
+				sound (self, CHAN_AUTO, self.cushionnoise, 1, ATTN_NORM);
 			}
-			else {
-				SUB_CallAsSelf(self.bouncecontroller.think, self.bouncecontroller);
+			else if (self.cushionsounds==1)
+			{
+				sound (self, CHAN_AUTO, "misc/cushion2.wav", 1, ATTN_NORM);
+			}
+			else if (self.cushionsounds==2)
+			{
+				sound (self, CHAN_AUTO, "misc/cushion3.wav", 1, ATTN_NORM);
+			}
+			else if (self.cushionsounds==3)
+			{
+				sound (self, CHAN_AUTO, "misc/cushion4.wav", 1, ATTN_NORM);
+			}
+			else if (self.cushionsounds==4)
+			{
+				sound (self, CHAN_AUTO, "misc/cushion5.wav", 1, ATTN_NORM);
+			}
+			else if (self.cushionsounds==5)
+			{
+				sound (self, CHAN_AUTO, "misc/cushion6.wav", 1, ATTN_NORM);
+			}
+			else
+			{
+				sound (self, CHAN_AUTO, "misc/cushion1.wav", 1, ATTN_NORM);
 			}
 			
 			self.jump_flag = 0;
+			
+			//Fire trampoline targets on cushion landing
+			float ostate = self.state;
+			self.state = ostate | STATE_RM_CUSHIONED;
+			entity oactivator = activator;
+			activator = self;
+			entity oself = self;
+			self = self.cushion;
+			SUB_UseTargets();
+			self = oself;
+			activator = oactivator;
+			self.state = ostate;
 		}
 }
 

--- a/client.qc
+++ b/client.qc
@@ -1471,6 +1471,8 @@ void() PlayerPostThink =
 
 	if (!(self.flags & FL_ONGROUND))
 		self.jump_flag = self.velocity_z;
+	else
+		self.jump_flag = 0;
 
 	if (self.health > self.max_health) //dumptruck_ds --  this replaces item_megahealth_rot in items.qc
 

--- a/client.qc
+++ b/client.qc
@@ -1428,47 +1428,54 @@ if ((self.jump_flag < -100) && (self.flags & FL_ONGROUND) && (self.health > 0))
 {
 		if (self.cushion) 
 		{
-			if (self.cushionnoise!="") {
-				sound (self, CHAN_AUTO, self.cushionnoise, 1, ATTN_NORM);
+			// checks if the player hit the ground before any scheduled trampoline push happened
+			// if there's one, forces it to happen now
+			if (self.bouncecontroller.nextthink <= time) {
+				if (self.cushionnoise!="") {
+					sound (self, CHAN_AUTO, self.cushionnoise, 1, ATTN_NORM);
+				}
+				else if (self.cushionsounds==1)
+				{
+					sound (self, CHAN_AUTO, "misc/cushion2.wav", 1, ATTN_NORM);
+				}
+				else if (self.cushionsounds==2)
+				{
+					sound (self, CHAN_AUTO, "misc/cushion3.wav", 1, ATTN_NORM);
+				}
+				else if (self.cushionsounds==3)
+				{
+					sound (self, CHAN_AUTO, "misc/cushion4.wav", 1, ATTN_NORM);
+				}
+				else if (self.cushionsounds==4)
+				{
+					sound (self, CHAN_AUTO, "misc/cushion5.wav", 1, ATTN_NORM);
+				}
+				else if (self.cushionsounds==5)
+				{
+					sound (self, CHAN_AUTO, "misc/cushion6.wav", 1, ATTN_NORM);
+				}
+				else
+				{
+					sound (self, CHAN_AUTO, "misc/cushion1.wav", 1, ATTN_NORM);
+				}
+							
+				//Fire trampoline targets on cushion landing
+				float ostate = self.state;
+				self.state = ostate | STATE_RM_CUSHIONED;
+				entity oactivator = activator;
+				activator = self;
+				entity oself = self;
+				self = self.cushion;
+				SUB_UseTargets();
+				self = oself;
+				activator = oactivator;
+				self.state = ostate;
 			}
-			else if (self.cushionsounds==1)
-			{
-				sound (self, CHAN_AUTO, "misc/cushion2.wav", 1, ATTN_NORM);
-			}
-			else if (self.cushionsounds==2)
-			{
-				sound (self, CHAN_AUTO, "misc/cushion3.wav", 1, ATTN_NORM);
-			}
-			else if (self.cushionsounds==3)
-			{
-				sound (self, CHAN_AUTO, "misc/cushion4.wav", 1, ATTN_NORM);
-			}
-			else if (self.cushionsounds==4)
-			{
-				sound (self, CHAN_AUTO, "misc/cushion5.wav", 1, ATTN_NORM);
-			}
-			else if (self.cushionsounds==5)
-			{
-				sound (self, CHAN_AUTO, "misc/cushion6.wav", 1, ATTN_NORM);
-			}
-			else
-			{
-				sound (self, CHAN_AUTO, "misc/cushion1.wav", 1, ATTN_NORM);
+			else {
+				SUB_CallAsSelf(self.bouncecontroller.think, self.bouncecontroller);
 			}
 			
 			self.jump_flag = 0;
-			
-			//Fire trampoline targets on cushion landing
-			float ostate = self.state;
-			self.state = ostate | STATE_RM_CUSHIONED;
-			entity oactivator = activator;
-			activator = self;
-			entity oself = self;
-			self = self.cushion;
-			SUB_UseTargets();
-			self = oself;
-			activator = oactivator;
-			self.state = ostate;
 		}
 }
 

--- a/defs.qc
+++ b/defs.qc
@@ -1079,6 +1079,8 @@ void(entity client, float density, vector color) csf_set;
 .float elasticity;
 .float maxbounce;
 
+.entity bouncecontroller;
+
 // wiremesh-related
 
 .float onWiremesh;

--- a/defs.qc
+++ b/defs.qc
@@ -1079,8 +1079,6 @@ void(entity client, float density, vector color) csf_set;
 .float elasticity;
 .float maxbounce;
 
-.entity bouncecontroller;
-
 // wiremesh-related
 
 .float onWiremesh;

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -1646,21 +1646,28 @@ When player is touching this entity, she can climb by pushing jump."
 
 Player will bounce off of this like a trampoline, reflecting velocity.
 
+The actual bounce will happen when the player hits any horizontal face that's inside the trigger, regardless of trigger height, and automatically in the direction of the face - if the surface is at an angled surface, the bouncee will be shot back in that direction.
+
 'elasticity' sets how much velocity is boosted after a bounce (ignoring gravity); default of 1 is perfectly elastic, values less than 1 will result in lower bounces, and values higher than 1 will provide a higher boost. Small changes in elasticity greatly effect velocity. Elasticity values greater than 1 work well with angled trampolines (see below).
 
 'maxbounce' sets the maximum vertical velocity that a player can achieve using the trampoline.
+
+'punchangle' Defines a custom bounce angle. If unset, entities bounce in the direction of the face they hit, or straight upwards if the 'bounce on touch' flag is set. It's recommended to keep the yaw angle close to 90 for a more effective bouncing.
 
 NOTE: A player can continue to bounce indefinitely and gain height on an elasticity > 1 trampoline, which can compromise progression; to prevent this, always set a maxbounce value if using an elasticity > 1 trampoline.
 
 'speed' sets the minimum vertical velocity that a player must have to bounce on the trampoline. If set to -1, the trampoline cannot bounce players, and will only act as a cushion.
 
 Spawnflags:
-- 'Angled' overrides the default upwards orientation and instead performs a trace from the entity using the trampoline to the surface below it, and returns the surface normal. This can be used to make angled trampolines. Be aware that the Quake engine does not support non-axial trigger brushes, so a diagonally-rotated trampoline must be simulated by constructing a series of trigger_trampolines in a staircase pattern approximating the angle."
+- 'Bounce on touch' makes entities bounce when they hit the top of the trigger instead of the face below, and always in a straight upwards angle. Useful when the surface underneath is bumpy and irregular. If you need to bounce at an angle, set it the 'punchangle' field in conjunction of this flag.
+"
 [
 	elasticity(string) : "How much velocity is boosted after a bounce, ignoring gravity." : "1"
 	
 	maxbounce(string) : "The maximum vertical velocity that a player can achieve using the trampoline." : "0"
 	
+	punchangle(string) : "Custom bounce angle, in 'yaw pitch roll' notation."
+
 	sounds(choices) : "Sound" : 0 =
 	[
 		0: "Default (Metal)"
@@ -1673,7 +1680,7 @@ Spawnflags:
 	
 	spawnflags(Flags) =
 	[
-	1 : "Angled" : 0
+	2 : "Bounce on touch" : 0
 	]
 	
 	noise(string) : "Sound file for the 'bounce' sound (if set, overrides 'sounds')"

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -1659,14 +1659,15 @@ NOTE: A player can continue to bounce indefinitely and gain height on an elastic
 'speed' sets the minimum vertical velocity that a player must have to bounce on the trampoline. If set to -1, the trampoline cannot bounce players, and will only act as a cushion.
 
 Spawnflags:
-- 'Bounce on touch' makes entities bounce when they hit the top of the trigger instead of the face below, and always in a straight upwards angle. Useful when the surface underneath is bumpy and irregular. If you need to bounce at an angle, set it the 'punchangle' field in conjunction of this flag.
+- 'Bounce on touch' makes entities bounce when they hit the top of the trigger instead of the face below, and always in a straight upwards angle. Useful when the surface underneath is bumpy or irregular. If you need to bounce at an angle, set the 'punchangle' field in conjunction with this flag.
+- 'Disable bounds check' disables precise bounding box calculations. Only really needed when the trampoline trigger is sitting atop a clip brush instead of a regular solid (either worldspawn or brush entity). The code is able to detect those kind of situations automatically, but to be sure you can enforce it with this option.
 "
 [
 	elasticity(string) : "How much velocity is boosted after a bounce, ignoring gravity." : "1"
 	
 	maxbounce(string) : "The maximum vertical velocity that a player can achieve using the trampoline." : "0"
 	
-	punchangle(string) : "Custom bounce angle, in 'yaw pitch roll' notation."
+	punchangle(string) : "Custom bounce angle, in 'pitch yaw roll' notation. Positive pitch points upwards like in 'angles'."
 
 	sounds(choices) : "Sound" : 0 =
 	[
@@ -1681,6 +1682,7 @@ Spawnflags:
 	spawnflags(Flags) =
 	[
 	2 : "Bounce on touch" : 0
+	4 : "Disable bounds check" : 0
 	]
 	
 	noise(string) : "Sound file for the 'bounce' sound (if set, overrides 'sounds')"

--- a/rm_mechanics.qc
+++ b/rm_mechanics.qc
@@ -169,7 +169,8 @@ void() trampoline_touch = {
 	// otherwise, just fetch a reference to the existing one
 	else
 		ctrl = other.bouncecontroller;
-
+	
+	ctrl.think = bouncecontroller_think;
 	ctrl.enemy = self;
 
 	if (
@@ -200,7 +201,7 @@ void() trampoline_touch = {
 		playervel_z = self.maxbounce;
 
 	ctrl.movedir = playervel;
-	ctrl.think = bouncecontroller_think;
+	
 	ctrl.nextthink = time + timetobounce;
 }
 

--- a/rm_mechanics.qc
+++ b/rm_mechanics.qc
@@ -354,10 +354,10 @@ void() trigger_trampoline = {
 		setsize(self, self.mins, [self.maxs_x, self.maxs_y, self.mins_z + 48]);
 	}
 
-	if (mapname == "rm_heretics") {
-		dprint("rm_heretics found. Turning on the Bounce on Touch and No Bounds Check flags for all trampolines\n");
-		self.spawnflags |= BOUNCE_ON_TOUCH + BOUNCE_NO_BOUNDS_CHECK;
-	}
+	//if (mapname == "rm_heretics") {
+	//	dprint("rm_heretics found. Turning on the Bounce on Touch and No Bounds Check flags for all trampolines\n");
+	//	self.spawnflags |= BOUNCE_ON_TOUCH + BOUNCE_NO_BOUNDS_CHECK;
+	//}
 
 	precache_sound ("misc/bounce1.wav");
 	precache_sound ("misc/bounce2.wav");

--- a/rm_mechanics.qc
+++ b/rm_mechanics.qc
@@ -97,6 +97,15 @@ void() trampoline_touch = {
 	vector traceorigin;
 	float fraction, disttoplane, bouncehit;
 
+	/*
+	Does a lot of traces downwards to see where the entity will land.
+	The "touch point" to be considered is the one closest to the bottom of the entity.
+	From that, we basically take the distance to the bounce, and the surface normal
+	for the entity be pushed towards.
+
+	This is also used for the bounds check. If one of the traces hit a point
+	outside of the trigger's area it gets marked as "not hit"
+	*/
 
 	traceline(other.origin + [0, 0, other.mins_z] , other.origin + [0, 0, other.mins_z] - '0 0 512', FALSE, other);
 	//dprint7("Trace 1: ", vtos(trace_endpos), ", absmin: ", vtos(self.absmin), ", absmax: ", vtos(self.absmax), "\n");
@@ -225,10 +234,12 @@ void() trampoline_touch = {
 	}
 	
 
+	// optional bounce angle override
 	if (self.punchangle != '0 0 0'){
 		makevectors([-self.punchangle_x, self.punchangle_y, self.punchangle_z]);
 		up = v_forward;
 	}
+	// "bounce on touch" triggers will have the bounce angle upwards by default
 	else if (self.spawnflags & BOUNCE_ON_TOUCH)
 		up = '0 0 1';
 	
@@ -266,14 +277,16 @@ void() trampoline_touch = {
 	float timetobounce;
 	
 
-	// calculates at which time the bounce will happen.
-	// currently it's set to be at the surface and it works fine
+	// Calculates at which time the bounce will happen.
+	// Currently it's set to be at the surface and it works fine.
+
+	// When the "bounce on touch" flag is on, the bounce will
+	// happen when the entity hits the top of the original trigger size.
+	
 	if (self.spawnflags & BOUNCE_ON_TOUCH)
 		timetobounce = fabs((self.absmin_z + self.height - other.absmin_z)/other.velocity_z);
 	else
 		timetobounce = fabs(disttoplane/other.velocity_z);
-
-	
 
 	// calculates the downwards velocity the player will have at the bounce point, accounting for gravity
 	float grav = cvar("sv_gravity");
@@ -337,8 +350,9 @@ void() trigger_trampoline = {
 	// 48 is enough to catch an entity falling 1500ups downwards at 30fps
 	// taller than that risks making the trigger to fire when it's not supposed to
 	self.height = self.size_z;
-	if (self.size_z < 48)
+	if (self.size_z < 48){
 		setsize(self, self.mins, [self.maxs_x, self.maxs_y, self.mins_z + 48]);
+	}
 
 	if (mapname == "rm_heretics") {
 		dprint("rm_heretics found. Turning on the Bounce on Touch and No Bounds Check flags for all trampolines\n");

--- a/rm_mechanics.qc
+++ b/rm_mechanics.qc
@@ -19,79 +19,128 @@ speed indefinitely. Default of 0 means no limit.
 
 float TRACE_TO_SURFACE = 1;
 
+
+void() bouncecontroller_think = {
+
+	if (self != self.owner.bouncecontroller) { // lost link
+		remove(self);
+		return;
+	}
+
+	entity bouncee = self.owner;
+	entity trp = self.enemy;
+	
+	if (bouncee.button2 || bouncee.flags & FL_MONSTER || (bouncee.movetype == MOVETYPE_BOUNCE && bouncee.solid == SOLID_BBOX)) {
+		bouncee.flags &~= FL_ONGROUND;
+		dprint6(bouncee.classname, " (", ftos(time), "s): Bounce velocity ", vtos(self.movedir), "\n");
+		bouncee.velocity = self.movedir;
+
+		if (trp.noise != "")
+			sound (trp, CHAN_AUTO, trp.noise, 1, ATTN_NORM);
+		else if (trp.sounds == 1)
+			sound (trp, CHAN_AUTO, "misc/bounce2.wav", 1, ATTN_NORM);
+		else if (trp.sounds == 2)
+			sound (trp, CHAN_AUTO, "misc/bounce3.wav", 1, ATTN_NORM);
+		else if (trp.sounds == 3)
+			sound (trp, CHAN_AUTO, "misc/bounce4.wav", 1, ATTN_NORM);
+		else if (trp.sounds == 4)
+			sound (trp, CHAN_AUTO, "misc/bounce5.wav", 1, ATTN_NORM);
+		else if (trp.sounds == 5)
+			sound (trp, CHAN_AUTO, "misc/bounce6.wav", 1, ATTN_NORM);
+		else
+			sound (trp, CHAN_AUTO, "misc/bounce1.wav", 1, ATTN_NORM);
+					
+		float ostate = bouncee.state;
+		bouncee.maxbounce++;
+		bouncee.state = ostate | STATE_RM_BOUNCING;
+		activator = bouncee;
+		SUB_UseTargets();
+		bouncee.state = ostate;
+	}
+	self.nextthink = 0;
+}
+
 void() trampoline_touch =
 {
-	// Enforce a minimum velocity the player must fall so they won't just bounce endlessly
-	float minSpeed = -fabs(self.speed);
-
+		
 	// from Copper -- dumptruck_ds
-	if (!((other.flags & FL_MONSTER || (other.movetype == MOVETYPE_BOUNCE && other.solid == SOLID_BBOX))	
-	|| (CheckValidTouch()))) return;
+	if (!(CheckValidTouch() || (other.flags & FL_MONSTER || (other.movetype == MOVETYPE_BOUNCE && other.solid == SOLID_BBOX)) ))
+		return;
 	
-	vector up = '0 0 1';
+	vector up;
 	
-	if (self.spawnflags & TRACE_TO_SURFACE) {
-		vector offset = other.origin;
-		offset[2] -= 300;
-		traceline(other.origin, offset, FALSE, other);
+	traceline(other.origin + [0, 0, other.mins_z] , other.origin + [0, 0, other.mins_z] - '0 0 512', FALSE, other);
+
+	if (self.spawnflags & TRACE_TO_SURFACE)
 		up = trace_plane_normal;
-	}
+	else
+		up = '0 0 1';
 	
 	// Player doesn't take any fall damage when landing on a trampoline
 	other.cushion = self;
 	
+	// Set cushion sounds to be fired in PlayerPostThink
 	other.cushionnoise = self.noise2;
-	
 	other.cushionsounds = self.sounds;
 	
-	if(self.speed == -1) return; //Cushion only (no bounce)
 	
-	if (other.button2 || other.flags & FL_MONSTER || (other.movetype == MOVETYPE_BOUNCE && other.solid == SOLID_BBOX)) {
-	
-		if (other.velocity[2] < minSpeed) {
-			vector playervel = other.velocity;
-			// reflection equation
-			playervel = playervel - 2 * playervel * up * up * (self.elasticity);
-			
-			// if maxbounce is set, cap vertical movement speed at maxbounce
-			if (self.maxbounce > 0 && playervel[2] > self.maxbounce)
-				playervel[2] = self.maxbounce;
-			
-			other.velocity = playervel;
-			if (self.noise != "")
-				sound (self, CHAN_AUTO, self.noise, 1, ATTN_NORM);
-			else if (self.sounds == 1)
-				sound (self, CHAN_AUTO, "misc/bounce2.wav", 1, ATTN_NORM);
-			else if (self.sounds == 2)
-				sound (self, CHAN_AUTO, "misc/bounce3.wav", 1, ATTN_NORM);
-			else if (self.sounds == 3)
-				sound (self, CHAN_AUTO, "misc/bounce4.wav", 1, ATTN_NORM);
-			else if (self.sounds == 4)
-				sound (self, CHAN_AUTO, "misc/bounce5.wav", 1, ATTN_NORM);
-			else if (self.sounds == 5)
-				sound (self, CHAN_AUTO, "misc/bounce6.wav", 1, ATTN_NORM);
-			else
-				sound (self, CHAN_AUTO, "misc/bounce1.wav", 1, ATTN_NORM);
-				
-			//Fire trampoline targets on bounce
-			entity bouncee = other;
-			float ostate = bouncee.state;
-			bouncee.maxbounce++;
-			bouncee.state = ostate | STATE_RM_BOUNCING;
-			activator = other;
-			SUB_UseTargets();
-			bouncee.state = ostate;
-		}
+	if (
+		other.velocity_z > -fabs(self.speed) // Enforce a minimum velocity the player must fall so they won't just bounce endlessly
+		|| self.speed == -1 // Cushion only (no bounce)
+	) 
+		return;
+
+	entity ctrl;
+
+	// setup bounce controller if not created yet
+	if (other.bouncecontroller.classname != "bouncecontroller") {
+		
+		ctrl = spawn();
+		other.bouncecontroller = ctrl;
+		ctrl.classname = "bouncecontroller";
+		ctrl.owner = other;
 	}
+	// otherwise, just fetch a reference to the existing one
+	else
+		ctrl = other.bouncecontroller;
+
+	ctrl.enemy = self;
+
+	vector playervel = other.velocity;
 	
+	// calculates at which time the bounce will happen.
+	// 16u off the surface, so it's equivalent to the bounce point of the original code,
+	// but could theoretically set to 0
+	float timetobounce = fabs((trace_fraction*512 - 16)/other.velocity_z);
+
+	// calculates the downwards velocity the player will have at the bounce point, accounting for gravity
+	float grav = cvar("sv_gravity");
+	if (other.gravity) grav *= other.gravity;
+	playervel_z -= timetobounce * grav;
+
+	// reflection equation
+	// small correction factor for bounce velocity to be more or less consistent between jumps
+	playervel = playervel - 2 * playervel * up * up * self.elasticity + [0, 0, 6];
+	
+	// if maxbounce is set, cap vertical movement speed at maxbounce
+	if (self.maxbounce > 0 && playervel_z > self.maxbounce)
+		playervel_z = self.maxbounce;
+
+	ctrl.movedir = playervel;
+	ctrl.think = bouncecontroller_think;
+	ctrl.nextthink = time + timetobounce;
 }
 
-void() trigger_trampoline =
-{
+
+void() trigger_trampoline = {
 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
 		return;
 
 	InitTrigger ();
+	// stretches the trigger so it's at least 64u tall
+	if (self.size_z < 64)
+		setsize(self, self.mins, [self.maxs_x, self.maxs_y, self.mins_z + 64]);
+
 	precache_sound ("misc/bounce1.wav");
 	precache_sound ("misc/bounce2.wav");
 	precache_sound ("misc/bounce3.wav");
@@ -104,7 +153,7 @@ void() trigger_trampoline =
 		
 	if (self.noise2 != "")
 		precache_sound(self.noise2);
-		
+	
 	self.touch = trampoline_touch;
 	if (!self.speed)
 		self.speed = 200;
@@ -115,6 +164,7 @@ void() trigger_trampoline =
 	if (!self.maxbounce)
 		self.maxbounce = 0;
 };
+
 
 /*
 ===============================================================================

--- a/rm_mechanics.qc
+++ b/rm_mechanics.qc
@@ -19,48 +19,6 @@ speed indefinitely. Default of 0 means no limit.
 
 float TRACE_TO_SURFACE = 1;
 
-void() cushionself = {
-	if (self.cushionnoise!="") {
-		sound (self, CHAN_AUTO, self.cushionnoise, 1, ATTN_NORM);
-	}
-	else if (self.cushionsounds==1)
-	{
-		sound (self, CHAN_AUTO, "misc/cushion2.wav", 1, ATTN_NORM);
-	}
-	else if (self.cushionsounds==2)
-	{
-		sound (self, CHAN_AUTO, "misc/cushion3.wav", 1, ATTN_NORM);
-	}
-	else if (self.cushionsounds==3)
-	{
-		sound (self, CHAN_AUTO, "misc/cushion4.wav", 1, ATTN_NORM);
-	}
-	else if (self.cushionsounds==4)
-	{
-		sound (self, CHAN_AUTO, "misc/cushion5.wav", 1, ATTN_NORM);
-	}
-	else if (self.cushionsounds==5)
-	{
-		sound (self, CHAN_AUTO, "misc/cushion6.wav", 1, ATTN_NORM);
-	}
-	else
-	{
-		sound (self, CHAN_AUTO, "misc/cushion1.wav", 1, ATTN_NORM);
-	}
-				
-	//Fire trampoline targets on cushion landing
-	float ostate = self.state;
-	self.state = ostate | STATE_RM_CUSHIONED;
-	entity oactivator = activator;
-	activator = self;
-	entity oself = self;
-	self = self.cushion;
-	SUB_UseTargets();
-	self = oself;
-	activator = oactivator;
-	self.state = ostate;
-}
-
 void() bouncecontroller_think = {
 
 	if (self != self.owner.bouncecontroller) { // lost link

--- a/rm_mechanics.qc
+++ b/rm_mechanics.qc
@@ -92,20 +92,20 @@ void() trampoline_touch = {
 	float fraction;
 
 	traceline(other.origin + [0, 0, other.mins_z] , other.origin + [0, 0, other.mins_z] - '0 0 512', FALSE, other);
-	dprint7("Trace 1: ", vtos(trace_endpos), ", absmin: ", vtos(self.absmin), ", absmax: ", vtos(self.absmax), "\n");
+	//dprint7("Trace 1: ", vtos(trace_endpos), ", absmin: ", vtos(self.absmin), ", absmax: ", vtos(self.absmax), "\n");
 	if (!checkbounds(trace_endpos + '0 0 8', self.absmin + '1 1 1', self.absmax - '1 1 1')) {
-		dprint("Trace 1 out of bounds.\n");
+		//dprint("Trace 1 out of bounds.\n");
 		return;
 	}
 	fraction = trace_fraction;
 	normal = trace_plane_normal;
 
 	traceline(other.origin + [other.mins_x, other.mins_y, other.mins_z] , other.origin + [other.mins_x, other.mins_y, other.mins_z] - '0 0 512', FALSE, other);
-	dprint7("Trace 2: ", vtos(trace_endpos), ", absmin: ", vtos(self.absmin), ", absmax: ", vtos(self.absmax), "\n");
+	//dprint7("Trace 2: ", vtos(trace_endpos), ", absmin: ", vtos(self.absmin), ", absmax: ", vtos(self.absmax), "\n");
 	if (trace_fraction < fraction) {
-		dprint("Trace 2 shorter. Replacing\n");
+		//dprint("Trace 2 shorter. Replacing\n");
 		if (!checkbounds(trace_endpos + '0 0 8', self.absmin + '1 1 1', self.absmax - '1 1 1')) {
-			dprint("Trace 2 out of bounds.\n");
+			//dprint("Trace 2 out of bounds.\n");
 			return;
 		}
 		fraction = trace_fraction;
@@ -113,11 +113,11 @@ void() trampoline_touch = {
 	}
 
 	traceline(other.origin + [other.maxs_x, other.mins_y, other.mins_z] , other.origin + [other.maxs_x, other.mins_y, other.mins_z] - '0 0 512', FALSE, other);
-	dprint7("Trace 3: ", vtos(trace_endpos), ", absmin: ", vtos(self.absmin), ", absmax: ", vtos(self.absmax), "\n");
+	//dprint7("Trace 3: ", vtos(trace_endpos), ", absmin: ", vtos(self.absmin), ", absmax: ", vtos(self.absmax), "\n");
 	if (trace_fraction < fraction) {
-		dprint("Trace 3 shorter. Replacing\n");
+		//dprint("Trace 3 shorter. Replacing\n");
 		if (!checkbounds(trace_endpos + '0 0 8', self.absmin + '1 1 1', self.absmax - '1 1 1')){
-			dprint("Trace 3 out of bounds.\n");
+			//dprint("Trace 3 out of bounds.\n");
 			return;
 		}
 
@@ -126,11 +126,11 @@ void() trampoline_touch = {
 	}
 
 	traceline(other.origin + [other.mins_x, other.maxs_y, other.mins_z] , other.origin + [other.mins_x, other.maxs_y, other.mins_z] - '0 0 512', FALSE, other);
-	dprint7("Trace 4: ", vtos(trace_endpos), ", absmin: ", vtos(self.absmin), ", absmax: ", vtos(self.absmax), "\n");
+	//dprint7("Trace 4: ", vtos(trace_endpos), ", absmin: ", vtos(self.absmin), ", absmax: ", vtos(self.absmax), "\n");
 	if (trace_fraction < fraction) {
-		dprint("Trace 4 shorter. Replacing\n");
+		//dprint("Trace 4 shorter. Replacing\n");
 		if (!checkbounds(trace_endpos + '0 0 8', self.absmin + '1 1 1', self.absmax - '1 1 1')) {
-			dprint("Trace 4 out of bounds.\n");
+			//dprint("Trace 4 out of bounds.\n");
 			return;
 		}
 		fraction = trace_fraction;
@@ -138,11 +138,11 @@ void() trampoline_touch = {
 	}
 
 	traceline(other.origin + [other.maxs_x, other.maxs_y, other.mins_z] , other.origin + [other.maxs_x, other.maxs_y, other.mins_z] - '0 0 512', FALSE, other);
-	dprint7("Trace 5: ", vtos(trace_endpos), ", absmin: ", vtos(self.absmin), ", absmax: ", vtos(self.absmax), "\n");
+	//dprint7("Trace 5: ", vtos(trace_endpos), ", absmin: ", vtos(self.absmin), ", absmax: ", vtos(self.absmax), "\n");
 	if (trace_fraction < fraction) {
-		dprint("Trace 5 shorter. Replacing\n");
+		//dprint("Trace 5 shorter. Replacing\n");
 		if (!checkbounds(trace_endpos + '0 0 8', self.absmin + '1 1 1', self.absmax - '1 1 1')){
-			dprint("Trace 5 out of bounds.\n");
+			//dprint("Trace 5 out of bounds.\n");
 			return;
 		}
 		fraction = trace_fraction;

--- a/rm_mechanics.qc
+++ b/rm_mechanics.qc
@@ -21,6 +21,7 @@ speed indefinitely. Default of 0 means no limit.
 
 //float TRACE_TO_SURFACE = 1; // deprecated
 float BOUNCE_ON_TOUCH = 2;
+float BOUNCE_NO_BOUNDS_CHECK = 4;
 
 void() bouncecontroller_think = {
 
@@ -92,65 +93,137 @@ void() trampoline_touch = {
 	
 	vector up;
 	vector normal;
-	float fraction;
+	vector touchpoint;
+	vector traceorigin;
+	float fraction, disttoplane, bouncehit;
+
 
 	traceline(other.origin + [0, 0, other.mins_z] , other.origin + [0, 0, other.mins_z] - '0 0 512', FALSE, other);
 	//dprint7("Trace 1: ", vtos(trace_endpos), ", absmin: ", vtos(self.absmin), ", absmax: ", vtos(self.absmax), "\n");
-	if (!checkbounds(trace_endpos + '0 0 8', self.absmin + '1 1 1', self.absmax - '1 1 1')) {
+	if (checkbounds(trace_endpos + '0 0 8', self.absmin + '1 1 1', self.absmax - '1 1 1')) {
 		//dprint("Trace 1 out of bounds.\n");
-		return;
+		bouncehit = TRUE;
 	}
+
+	traceorigin	= other.origin + [0, 0, other.mins_z];
 	fraction = trace_fraction;
 	normal = trace_plane_normal;
+	touchpoint = trace_endpos;
 
 	traceline(other.origin + [other.mins_x, other.mins_y, other.mins_z] , other.origin + [other.mins_x, other.mins_y, other.mins_z] - '0 0 512', FALSE, other);
 	//dprint7("Trace 2: ", vtos(trace_endpos), ", absmin: ", vtos(self.absmin), ", absmax: ", vtos(self.absmax), "\n");
-	if (trace_fraction < fraction) {
+	if (trace_fraction <= fraction) {
 		//dprint("Trace 2 shorter. Replacing\n");
-		if (!checkbounds(trace_endpos + '0 0 8', self.absmin + '1 1 1', self.absmax - '1 1 1')) {
+		if (checkbounds(trace_endpos + '0 0 8', self.absmin + '1 1 1', self.absmax - '1 1 1')) {
 			//dprint("Trace 2 out of bounds.\n");
-			return;
+			bouncehit = TRUE;
 		}
+	
+		traceorigin	= other.origin + [other.mins_x, other.mins_y, other.mins_z];
 		fraction = trace_fraction;
 		normal = trace_plane_normal;
+		touchpoint = trace_endpos;
 	}
 
 	traceline(other.origin + [other.maxs_x, other.mins_y, other.mins_z] , other.origin + [other.maxs_x, other.mins_y, other.mins_z] - '0 0 512', FALSE, other);
 	//dprint7("Trace 3: ", vtos(trace_endpos), ", absmin: ", vtos(self.absmin), ", absmax: ", vtos(self.absmax), "\n");
-	if (trace_fraction < fraction) {
+	if (trace_fraction <= fraction) {
 		//dprint("Trace 3 shorter. Replacing\n");
-		if (!checkbounds(trace_endpos + '0 0 8', self.absmin + '1 1 1', self.absmax - '1 1 1')){
+		if (checkbounds(trace_endpos + '0 0 8', self.absmin + '1 1 1', self.absmax - '1 1 1')){
 			//dprint("Trace 3 out of bounds.\n");
-			return;
+			bouncehit = TRUE;
 		}
-
+	
+		traceorigin = other.origin + [other.maxs_x, other.mins_y, other.mins_z];
 		fraction = trace_fraction;
 		normal = trace_plane_normal;
+		touchpoint = trace_endpos;
 	}
 
 	traceline(other.origin + [other.mins_x, other.maxs_y, other.mins_z] , other.origin + [other.mins_x, other.maxs_y, other.mins_z] - '0 0 512', FALSE, other);
 	//dprint7("Trace 4: ", vtos(trace_endpos), ", absmin: ", vtos(self.absmin), ", absmax: ", vtos(self.absmax), "\n");
-	if (trace_fraction < fraction) {
+	if (trace_fraction <= fraction) {
 		//dprint("Trace 4 shorter. Replacing\n");
-		if (!checkbounds(trace_endpos + '0 0 8', self.absmin + '1 1 1', self.absmax - '1 1 1')) {
+		if (checkbounds(trace_endpos + '0 0 8', self.absmin + '1 1 1', self.absmax - '1 1 1')) {
 			//dprint("Trace 4 out of bounds.\n");
-			return;
+			bouncehit = TRUE;
 		}
+	
+		traceorigin = other.origin + [other.mins_x, other.maxs_y, other.mins_z];
 		fraction = trace_fraction;
 		normal = trace_plane_normal;
+		touchpoint = trace_endpos;
 	}
 
 	traceline(other.origin + [other.maxs_x, other.maxs_y, other.mins_z] , other.origin + [other.maxs_x, other.maxs_y, other.mins_z] - '0 0 512', FALSE, other);
 	//dprint7("Trace 5: ", vtos(trace_endpos), ", absmin: ", vtos(self.absmin), ", absmax: ", vtos(self.absmax), "\n");
-	if (trace_fraction < fraction) {
+	if (trace_fraction <= fraction) {
 		//dprint("Trace 5 shorter. Replacing\n");
-		if (!checkbounds(trace_endpos + '0 0 8', self.absmin + '1 1 1', self.absmax - '1 1 1')){
+		if (checkbounds(trace_endpos + '0 0 8', self.absmin + '1 1 1', self.absmax - '1 1 1')){
 			//dprint("Trace 5 out of bounds.\n");
-			return;
+			bouncehit = TRUE;
 		}
+	
+		traceorigin = other.origin + [other.maxs_x, other.maxs_y, other.mins_z];
 		fraction = trace_fraction;
 		normal = trace_plane_normal;
+		touchpoint = trace_endpos;
 	}
+
+	traceline(other.origin + [other.maxs_x*0.75, other.maxs_y*0.75, other.mins_z] , other.origin + [other.maxs_x*0.75, other.maxs_y*0.75, other.mins_z] - '0 0 512', FALSE, other);
+	//dprint7("Trace 6: ", vtos(trace_endpos), ", absmin: ", vtos(self.absmin), ", absmax: ", vtos(self.absmax), "\n");
+	if (trace_fraction <= fraction) {
+		//dprint("Trace 6 shorter. Replacing\n");
+		if (checkbounds(trace_endpos + '0 0 8', self.absmin + '1 1 1', self.absmax - '1 1 1')){
+			//dprint("Trace 6 out of bounds.\n");
+			bouncehit = TRUE;
+		}
+	
+		traceorigin = other.origin + [other.maxs_x*0.75, other.maxs_y*0.75, other.mins_z];
+		fraction = trace_fraction;
+		normal = trace_plane_normal;
+		touchpoint = trace_endpos;
+	}
+
+	traceline(other.origin + [other.mins_x*0.75, other.mins_y*0.75, other.mins_z] , other.origin + [other.mins_x*0.75, other.mins_y*0.75, other.mins_z] - '0 0 512', FALSE, other);
+	//dprint7("Trace 2: ", vtos(trace_endpos), ", absmin: ", vtos(self.absmin), ", absmax: ", vtos(self.absmax), "\n");
+	if (trace_fraction <= fraction) {
+		//dprint("Trace 2 shorter. Replacing\n");
+		if (checkbounds(trace_endpos + '0 0 8', self.absmin + '1 1 1', self.absmax - '1 1 1')) {
+			//dprint("Trace 2 out of bounds.\n");
+			bouncehit = TRUE;
+		}
+	
+		traceorigin	= other.origin + [other.mins_x*0.75, other.mins_y*0.75, other.mins_z];
+		fraction = trace_fraction;
+		normal = trace_plane_normal;
+		touchpoint = trace_endpos;
+	}
+
+	if (!bouncehit && !(self.spawnflags & BOUNCE_NO_BOUNDS_CHECK))
+		return;
+
+	up = normal;
+
+	disttoplane = fabs(traceorigin_z - touchpoint_z);
+	
+	// Checks if there's something between the entity and the bounce point that's outside
+	// the trigger's original bounds - for when you have something covering the
+	// trampoline to "disable" it.
+	// This must be done in a separate check, not in the bounds check,
+	// because it must happen even when the "no bounds check" flag is on.
+	if (touchpoint_z > self.absmin_z + self.height)
+		return;
+
+	// If the highest trace still fell below the trigger's lower bound,
+	// set that as the bounce point, and set the default bounce angle as upwards.
+	// This evaluation will only ever be true if the "no bounds check" flag is on,
+	// otherwise the function would early out at the bouncehit check.
+	if (touchpoint_z < self.absmin_z) {
+		disttoplane = fabs(traceorigin_z - self.absmin_z);
+		up = '0 0 1';
+	}
+	
 
 	if (self.punchangle != '0 0 0'){
 		makevectors([-self.punchangle_x, self.punchangle_y, self.punchangle_z]);
@@ -158,8 +231,7 @@ void() trampoline_touch = {
 	}
 	else if (self.spawnflags & BOUNCE_ON_TOUCH)
 		up = '0 0 1';
-	else
-		up = normal;
+	
 		
 	// Player doesn't take any fall damage when landing on a trampoline
 	other.cushion = self;
@@ -192,7 +264,7 @@ void() trampoline_touch = {
 	vector playervel = other.velocity;
 
 	float timetobounce;
-	float disttoplane = fraction*512;
+	
 
 	// calculates at which time the bounce will happen.
 	// currently it's set to be at the surface and it works fine

--- a/rm_mechanics.qc
+++ b/rm_mechanics.qc
@@ -19,6 +19,47 @@ speed indefinitely. Default of 0 means no limit.
 
 float TRACE_TO_SURFACE = 1;
 
+void() cushionself = {
+	if (self.cushionnoise!="") {
+		sound (self, CHAN_AUTO, self.cushionnoise, 1, ATTN_NORM);
+	}
+	else if (self.cushionsounds==1)
+	{
+		sound (self, CHAN_AUTO, "misc/cushion2.wav", 1, ATTN_NORM);
+	}
+	else if (self.cushionsounds==2)
+	{
+		sound (self, CHAN_AUTO, "misc/cushion3.wav", 1, ATTN_NORM);
+	}
+	else if (self.cushionsounds==3)
+	{
+		sound (self, CHAN_AUTO, "misc/cushion4.wav", 1, ATTN_NORM);
+	}
+	else if (self.cushionsounds==4)
+	{
+		sound (self, CHAN_AUTO, "misc/cushion5.wav", 1, ATTN_NORM);
+	}
+	else if (self.cushionsounds==5)
+	{
+		sound (self, CHAN_AUTO, "misc/cushion6.wav", 1, ATTN_NORM);
+	}
+	else
+	{
+		sound (self, CHAN_AUTO, "misc/cushion1.wav", 1, ATTN_NORM);
+	}
+				
+	//Fire trampoline targets on cushion landing
+	float ostate = self.state;
+	self.state = ostate | STATE_RM_CUSHIONED;
+	entity oactivator = activator;
+	activator = self;
+	entity oself = self;
+	self = self.cushion;
+	SUB_UseTargets();
+	self = oself;
+	activator = oactivator;
+	self.state = ostate;
+}
 
 void() bouncecontroller_think = {
 
@@ -29,7 +70,11 @@ void() bouncecontroller_think = {
 
 	entity bouncee = self.owner;
 	entity trp = self.enemy;
+	entity oself;
+	float ostate, fired;
 	
+	dprint6(bouncee.classname, " (", ftos(time), "s): Bounce think, jump flag: ", ftos(bouncee.jump_flag), "\n");
+
 	if (bouncee.button2 || bouncee.flags & FL_MONSTER || (bouncee.movetype == MOVETYPE_BOUNCE && bouncee.solid == SOLID_BBOX)) {
 		bouncee.flags &~= FL_ONGROUND;
 		dprint6(bouncee.classname, " (", ftos(time), "s): Bounce velocity ", vtos(self.movedir), "\n");
@@ -50,11 +95,54 @@ void() bouncecontroller_think = {
 		else
 			sound (trp, CHAN_AUTO, "misc/bounce1.wav", 1, ATTN_NORM);
 					
-		float ostate = bouncee.state;
 		bouncee.maxbounce++;
-		bouncee.state = ostate | STATE_RM_BOUNCING;
+
+		fired = TRUE;
+	}
+	else if (bouncee.flags & FL_CLIENT && /*(bouncee.jump_flag < -100) &&*/ (bouncee.flags & FL_ONGROUND) && (bouncee.health > 0)) {
+		dprint4(bouncee.classname, " (", ftos(time), "s): Cushioned\n");
+		if (bouncee.cushionnoise!="") {
+			sound (self, CHAN_AUTO, bouncee.cushionnoise, 1, ATTN_NORM);
+		}
+		else if (bouncee.cushionsounds==1)
+		{
+			sound (bouncee, CHAN_AUTO, "misc/cushion2.wav", 1, ATTN_NORM);
+		}
+		else if (bouncee.cushionsounds==2)
+		{
+			sound (bouncee, CHAN_AUTO, "misc/cushion3.wav", 1, ATTN_NORM);
+		}
+		else if (bouncee.cushionsounds==3)
+		{
+			sound (bouncee, CHAN_AUTO, "misc/cushion4.wav", 1, ATTN_NORM);
+		}
+		else if (bouncee.cushionsounds==4)
+		{
+			sound (bouncee, CHAN_AUTO, "misc/cushion5.wav", 1, ATTN_NORM);
+		}
+		else if (bouncee.cushionsounds==5)
+		{
+			sound (bouncee, CHAN_AUTO, "misc/cushion6.wav", 1, ATTN_NORM);
+		}
+		else
+		{
+			sound (bouncee, CHAN_AUTO, "misc/cushion1.wav", 1, ATTN_NORM);
+		}
+
+		fired = TRUE;
+	}
+
+	if (fired) {
+		//Fire trampoline targets on cushion landing
+		ostate = bouncee.state;
+		bouncee.state = ostate | STATE_RM_CUSHIONED;
+		
 		activator = bouncee;
+		oself = self;
+		self = trp;
 		SUB_UseTargets();
+		self = oself;
+
 		bouncee.state = ostate;
 	}
 	self.nextthink = 0;

--- a/rm_mechanics.qc
+++ b/rm_mechanics.qc
@@ -197,9 +197,8 @@ void() trampoline_touch =
 	vector playervel = other.velocity;
 	
 	// calculates at which time the bounce will happen.
-	// 16u off the surface, so it's equivalent to the bounce point of the original code,
-	// but could theoretically set to 0
-	float timetobounce = fabs((trace_fraction*512 - 16)/other.velocity_z);
+	// currently it's set to be at the surface and it works fine
+	float timetobounce = fabs(fraction*512/other.velocity_z);
 
 	// calculates the downwards velocity the player will have at the bounce point, accounting for gravity
 	float grav = cvar("sv_gravity");
@@ -208,7 +207,7 @@ void() trampoline_touch =
 
 	// reflection equation
 	// small correction factor for bounce velocity to be more or less consistent between jumps
-	playervel = playervel - 2 * playervel * up * up * self.elasticity + [0, 0, 6];
+	playervel = playervel - 2*playervel * up * up * self.elasticity + [0, 0, (frametime*480) - 0.5];
 	
 	// if maxbounce is set, cap vertical movement speed at maxbounce
 	if (self.maxbounce > 0 && playervel_z > self.maxbounce)

--- a/rm_mechanics.qc
+++ b/rm_mechanics.qc
@@ -204,13 +204,12 @@ void() trampoline_touch = {
 	ctrl.nextthink = time + timetobounce;
 }
 
-void() trigger_trampoline =
-{
+
+void() trigger_trampoline = {
 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
 		return;
 
 	InitTrigger ();
-
 	// stretches the trigger upwards so it's at least 48u tall
 	// 48 is enough to catch an entity falling 1500ups downwards at 30fps
 	// taller than that risks making the trigger to fire when it's not supposed to
@@ -229,7 +228,7 @@ void() trigger_trampoline =
 		
 	if (self.noise2 != "")
 		precache_sound(self.noise2);
-		
+	
 	self.touch = trampoline_touch;
 	if (!self.speed)
 		self.speed = 200;
@@ -240,6 +239,7 @@ void() trigger_trampoline =
 	if (!self.maxbounce)
 		self.maxbounce = 0;
 };
+
 
 /*
 ===============================================================================

--- a/rm_mechanics.qc
+++ b/rm_mechanics.qc
@@ -88,13 +88,71 @@ void() trampoline_touch = {
 		return;
 	
 	vector up;
-	
-	traceline(other.origin + [0, 0, other.mins_z] , other.origin + [0, 0, other.mins_z] - '0 0 512', FALSE, other);
+	vector normal;
+	float fraction;
 
-	if (self.spawnflags & TRACE_TO_SURFACE)
-		up = trace_plane_normal;
-	else
-		up = '0 0 1';
+	traceline(other.origin + [0, 0, other.mins_z] , other.origin + [0, 0, other.mins_z] - '0 0 512', FALSE, other);
+	dprint7("Trace 1: ", vtos(trace_endpos), ", absmin: ", vtos(self.absmin), ", absmax: ", vtos(self.absmax), "\n");
+	if (!checkbounds(trace_endpos + '0 0 8', self.absmin + '1 1 1', self.absmax - '1 1 1')) {
+		dprint("Trace 1 out of bounds.\n");
+		return;
+	}
+	fraction = trace_fraction;
+	normal = trace_plane_normal;
+
+	traceline(other.origin + [other.mins_x, other.mins_y, other.mins_z] , other.origin + [other.mins_x, other.mins_y, other.mins_z] - '0 0 512', FALSE, other);
+	dprint7("Trace 2: ", vtos(trace_endpos), ", absmin: ", vtos(self.absmin), ", absmax: ", vtos(self.absmax), "\n");
+	if (trace_fraction < fraction) {
+		dprint("Trace 2 shorter. Replacing\n");
+		if (!checkbounds(trace_endpos + '0 0 8', self.absmin + '1 1 1', self.absmax - '1 1 1')) {
+			dprint("Trace 2 out of bounds.\n");
+			return;
+		}
+		fraction = trace_fraction;
+		normal = trace_plane_normal;
+	}
+
+	traceline(other.origin + [other.maxs_x, other.mins_y, other.mins_z] , other.origin + [other.maxs_x, other.mins_y, other.mins_z] - '0 0 512', FALSE, other);
+	dprint7("Trace 3: ", vtos(trace_endpos), ", absmin: ", vtos(self.absmin), ", absmax: ", vtos(self.absmax), "\n");
+	if (trace_fraction < fraction) {
+		dprint("Trace 3 shorter. Replacing\n");
+		if (!checkbounds(trace_endpos + '0 0 8', self.absmin + '1 1 1', self.absmax - '1 1 1')){
+			dprint("Trace 3 out of bounds.\n");
+			return;
+		}
+
+		fraction = trace_fraction;
+		normal = trace_plane_normal;
+	}
+
+	traceline(other.origin + [other.mins_x, other.maxs_y, other.mins_z] , other.origin + [other.mins_x, other.maxs_y, other.mins_z] - '0 0 512', FALSE, other);
+	dprint7("Trace 4: ", vtos(trace_endpos), ", absmin: ", vtos(self.absmin), ", absmax: ", vtos(self.absmax), "\n");
+	if (trace_fraction < fraction) {
+		dprint("Trace 4 shorter. Replacing\n");
+		if (!checkbounds(trace_endpos + '0 0 8', self.absmin + '1 1 1', self.absmax - '1 1 1')) {
+			dprint("Trace 4 out of bounds.\n");
+			return;
+		}
+		fraction = trace_fraction;
+		normal = trace_plane_normal;
+	}
+
+	traceline(other.origin + [other.maxs_x, other.maxs_y, other.mins_z] , other.origin + [other.maxs_x, other.maxs_y, other.mins_z] - '0 0 512', FALSE, other);
+	dprint7("Trace 5: ", vtos(trace_endpos), ", absmin: ", vtos(self.absmin), ", absmax: ", vtos(self.absmax), "\n");
+	if (trace_fraction < fraction) {
+		dprint("Trace 5 shorter. Replacing\n");
+		if (!checkbounds(trace_endpos + '0 0 8', self.absmin + '1 1 1', self.absmax - '1 1 1')){
+			dprint("Trace 5 out of bounds.\n");
+			return;
+		}
+		fraction = trace_fraction;
+		normal = trace_plane_normal;
+	}
+
+	//if (self.spawnflags & TRACE_TO_SURFACE)
+	up = normal;
+	//else
+	//	up = '0 0 1';
 	
 	// Player doesn't take any fall damage when landing on a trampoline
 	other.cushion = self;
@@ -103,7 +161,6 @@ void() trampoline_touch = {
 
 	// setup bounce controller if not created yet
 	if (other.bouncecontroller.classname != "bouncecontroller") {
-		
 		ctrl = spawn();
 		other.bouncecontroller = ctrl;
 		ctrl.classname = "bouncecontroller";
@@ -153,9 +210,11 @@ void() trigger_trampoline = {
 		return;
 
 	InitTrigger ();
-	// stretches the trigger so it's at least 64u tall
-	if (self.size_z < 64)
-		setsize(self, self.mins, [self.maxs_x, self.maxs_y, self.mins_z + 64]);
+	// stretches the trigger upwards so it's at least 48u tall
+	// 48 is enough to catch an entity falling 1500ups downwards at 30fps
+	// taller than that risks making the trigger to fire when it's not supposed to
+	if (self.size_z < 48)
+		setsize(self, self.mins, [self.maxs_x, self.maxs_y, self.mins_z + 48]);
 
 	precache_sound ("misc/bounce1.wav");
 	precache_sound ("misc/bounce2.wav");

--- a/rm_mechanics.qc
+++ b/rm_mechanics.qc
@@ -73,67 +73,42 @@ void() bouncecontroller_think = {
 	entity oself;
 	float ostate, fired;
 	
-	dprint6(bouncee.classname, " (", ftos(time), "s): Bounce think, jump flag: ", ftos(bouncee.jump_flag), "\n");
+	dprint6(bouncee.classname, " (", ftos(framecount), "): Bounce think, jump flag: ", ftos(bouncee.jump_flag), "\n");
 
-	if (bouncee.button2 || bouncee.flags & FL_MONSTER || (bouncee.movetype == MOVETYPE_BOUNCE && bouncee.solid == SOLID_BBOX)) {
+	if ((bouncee.button2 || bouncee.flags & FL_MONSTER || (bouncee.movetype == MOVETYPE_BOUNCE && bouncee.solid == SOLID_BBOX))
+		) {
 		bouncee.flags &~= FL_ONGROUND;
-		dprint6(bouncee.classname, " (", ftos(time), "s): Bounce velocity ", vtos(self.movedir), "\n");
+		dprint6(bouncee.classname, " (", ftos(framecount), "): Bounced. Velocity ", vtos(self.movedir), "\n");
 		bouncee.velocity = self.movedir;
 
-		if (trp.noise != "")
-			sound (trp, CHAN_AUTO, trp.noise, 1, ATTN_NORM);
-		else if (trp.sounds == 1)
-			sound (trp, CHAN_AUTO, "misc/bounce2.wav", 1, ATTN_NORM);
-		else if (trp.sounds == 2)
-			sound (trp, CHAN_AUTO, "misc/bounce3.wav", 1, ATTN_NORM);
-		else if (trp.sounds == 3)
-			sound (trp, CHAN_AUTO, "misc/bounce4.wav", 1, ATTN_NORM);
-		else if (trp.sounds == 4)
-			sound (trp, CHAN_AUTO, "misc/bounce5.wav", 1, ATTN_NORM);
-		else if (trp.sounds == 5)
-			sound (trp, CHAN_AUTO, "misc/bounce6.wav", 1, ATTN_NORM);
-		else
-			sound (trp, CHAN_AUTO, "misc/bounce1.wav", 1, ATTN_NORM);
+		if (trp.noise != "") sound(trp, CHAN_AUTO, trp.noise, 1, ATTN_NORM);
+		else if (trp.sounds == 1) sound(trp, CHAN_AUTO, "misc/bounce2.wav", 1, ATTN_NORM);
+		else if (trp.sounds == 2) sound(trp, CHAN_AUTO, "misc/bounce3.wav", 1, ATTN_NORM);
+		else if (trp.sounds == 3) sound(trp, CHAN_AUTO, "misc/bounce4.wav", 1, ATTN_NORM);
+		else if (trp.sounds == 4) sound(trp, CHAN_AUTO, "misc/bounce5.wav", 1, ATTN_NORM);
+		else if (trp.sounds == 5) sound(trp, CHAN_AUTO, "misc/bounce6.wav", 1, ATTN_NORM);
+		else sound (trp, CHAN_AUTO, "misc/bounce1.wav", 1, ATTN_NORM);
 					
 		bouncee.maxbounce++;
 
 		fired = TRUE;
 	}
-	else if (bouncee.flags & FL_CLIENT && /*(bouncee.jump_flag < -100) &&*/ (bouncee.flags & FL_ONGROUND) && (bouncee.health > 0)) {
-		dprint4(bouncee.classname, " (", ftos(time), "s): Cushioned\n");
-		if (bouncee.cushionnoise!="") {
-			sound (self, CHAN_AUTO, bouncee.cushionnoise, 1, ATTN_NORM);
-		}
-		else if (bouncee.cushionsounds==1)
-		{
-			sound (bouncee, CHAN_AUTO, "misc/cushion2.wav", 1, ATTN_NORM);
-		}
-		else if (bouncee.cushionsounds==2)
-		{
-			sound (bouncee, CHAN_AUTO, "misc/cushion3.wav", 1, ATTN_NORM);
-		}
-		else if (bouncee.cushionsounds==3)
-		{
-			sound (bouncee, CHAN_AUTO, "misc/cushion4.wav", 1, ATTN_NORM);
-		}
-		else if (bouncee.cushionsounds==4)
-		{
-			sound (bouncee, CHAN_AUTO, "misc/cushion5.wav", 1, ATTN_NORM);
-		}
-		else if (bouncee.cushionsounds==5)
-		{
-			sound (bouncee, CHAN_AUTO, "misc/cushion6.wav", 1, ATTN_NORM);
-		}
-		else
-		{
-			sound (bouncee, CHAN_AUTO, "misc/cushion1.wav", 1, ATTN_NORM);
-		}
-
+	// this will always fire through the PlayerPostThink call
+	else if (bouncee.flags & FL_CLIENT /*&& (bouncee.jump_flag < -100)*/ && (bouncee.flags & FL_ONGROUND) && (bouncee.health > 0)) {
+		dprint4(bouncee.classname, " (", ftos(framecount), "): Cushioned\n");
+		if (trp.noise2 != "") sound(bouncee, CHAN_AUTO, trp.noise2, 1, ATTN_NORM);
+		else if (trp.sounds == 1) sound(bouncee, CHAN_AUTO, "misc/cushion2.wav", 1, ATTN_NORM);
+		else if (trp.sounds == 2) sound(bouncee, CHAN_AUTO, "misc/cushion3.wav", 1, ATTN_NORM);
+		else if (trp.sounds == 3) sound(bouncee, CHAN_AUTO, "misc/cushion4.wav", 1, ATTN_NORM);
+		else if (trp.sounds == 4) sound(bouncee, CHAN_AUTO, "misc/cushion5.wav", 1, ATTN_NORM);
+		else if (trp.sounds == 5) sound(bouncee, CHAN_AUTO, "misc/cushion6.wav", 1, ATTN_NORM);
+		else sound(bouncee, CHAN_AUTO, "misc/cushion1.wav", 1, ATTN_NORM);
+		
 		fired = TRUE;
 	}
 
 	if (fired) {
-		//Fire trampoline targets on cushion landing
+		//Fire trampoline targets if bounced or cushioned
 		ostate = bouncee.state;
 		bouncee.state = ostate | STATE_RM_CUSHIONED;
 		
@@ -148,8 +123,7 @@ void() bouncecontroller_think = {
 	self.nextthink = 0;
 }
 
-void() trampoline_touch =
-{
+void() trampoline_touch = {
 		
 	// from Copper -- dumptruck_ds
 	if (!(CheckValidTouch() || (other.flags & FL_MONSTER || (other.movetype == MOVETYPE_BOUNCE && other.solid == SOLID_BBOX)) ))

--- a/rm_mechanics.qc
+++ b/rm_mechanics.qc
@@ -294,6 +294,39 @@ void() trampoline_touch = {
 	ctrl.nextthink = time + timetobounce;
 }
 
+/*
+Tests if trigger_trampoline is sitting on top of a clip brush, by doing 16 tracelines downwards
+spread across the trigger's horizontal area. If no more than 1/4 of the traces hit something,
+it assumes it's on top of a clip brush and enables the No Bounds Check flag if it wasn't before.
+*/
+void() trigger_trampoline_checkclip = {
+
+	float xstep = rint((self.size_x - 32)/4);
+	float ystep = rint((self.size_y - 32)/4);
+	vector trace_xy;
+	float x, y, hits;
+
+	for (y = 0; x < 4; x++) {
+		for (y = 0; y < 4; y++) {
+			trace_xy = [self.absmin_x + 16 + x*xstep, self.absmin_y + 16 + y*ystep, 0];
+			traceline(trace_xy + [0, 0, self.absmin_z + self.height], trace_xy + [0, 0, self.absmin_z - 1], FALSE, self);
+
+			if (trace_fraction < 1)
+				hits++;
+
+			if (hits > 4)
+				break;
+		}
+
+		if (hits > 4)
+			break;
+	}
+
+	if (hits < 4) {
+		dprint3("WARNING: trigger_trampoline at ", vtos((self.absmin + self.absmax)/2), " probably over clip brush, disabling bounds check\n");
+		self.spawnflags |= BOUNCE_NO_BOUNDS_CHECK;
+	}
+}
 
 void() trigger_trampoline = {
 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
@@ -329,6 +362,11 @@ void() trigger_trampoline = {
 		self.sounds = 0;
 	if (!self.maxbounce)
 		self.maxbounce = 0;
+
+	if (!(self.spawnflags & BOUNCE_NO_BOUNDS_CHECK)) {
+		self.think = trigger_trampoline_checkclip;
+		self.nextthink = time + 0.3;
+	}
 };
 
 

--- a/rm_mechanics.qc
+++ b/rm_mechanics.qc
@@ -51,7 +51,7 @@ void() bouncecontroller_think = {
 					
 		bouncee.maxbounce++;
 
-		fired = TRUE;
+		fired = STATE_RM_BOUNCING;
 	}
 	// this will always fire through the PlayerPostThink call
 	else if (bouncee.flags & FL_CLIENT && (bouncee.flags & FL_ONGROUND) && (bouncee.health > 0)) {
@@ -63,14 +63,14 @@ void() bouncecontroller_think = {
 		else if (trp.sounds == 4) sound(bouncee, CHAN_AUTO, "misc/cushion5.wav", 1, ATTN_NORM);
 		else if (trp.sounds == 5) sound(bouncee, CHAN_AUTO, "misc/cushion6.wav", 1, ATTN_NORM);
 		else sound(bouncee, CHAN_AUTO, "misc/cushion1.wav", 1, ATTN_NORM);
-		
-		fired = TRUE;
+
+		fired = STATE_RM_CUSHIONED;
 	}
 
 	if (fired) {
 		//Fire trampoline targets if bounced or cushioned
 		ostate = bouncee.state;
-		bouncee.state = ostate | STATE_RM_CUSHIONED;
+		bouncee.state = ostate | fired;
 		
 		activator = bouncee;
 		oself = self;

--- a/rm_mechanics.qc
+++ b/rm_mechanics.qc
@@ -19,128 +19,79 @@ speed indefinitely. Default of 0 means no limit.
 
 float TRACE_TO_SURFACE = 1;
 
-
-void() bouncecontroller_think = {
-
-	if (self != self.owner.bouncecontroller) { // lost link
-		remove(self);
-		return;
-	}
-
-	entity bouncee = self.owner;
-	entity trp = self.enemy;
-	
-	if (bouncee.button2 || bouncee.flags & FL_MONSTER || (bouncee.movetype == MOVETYPE_BOUNCE && bouncee.solid == SOLID_BBOX)) {
-		bouncee.flags &~= FL_ONGROUND;
-		dprint6(bouncee.classname, " (", ftos(time), "s): Bounce velocity ", vtos(self.movedir), "\n");
-		bouncee.velocity = self.movedir;
-
-		if (trp.noise != "")
-			sound (trp, CHAN_AUTO, trp.noise, 1, ATTN_NORM);
-		else if (trp.sounds == 1)
-			sound (trp, CHAN_AUTO, "misc/bounce2.wav", 1, ATTN_NORM);
-		else if (trp.sounds == 2)
-			sound (trp, CHAN_AUTO, "misc/bounce3.wav", 1, ATTN_NORM);
-		else if (trp.sounds == 3)
-			sound (trp, CHAN_AUTO, "misc/bounce4.wav", 1, ATTN_NORM);
-		else if (trp.sounds == 4)
-			sound (trp, CHAN_AUTO, "misc/bounce5.wav", 1, ATTN_NORM);
-		else if (trp.sounds == 5)
-			sound (trp, CHAN_AUTO, "misc/bounce6.wav", 1, ATTN_NORM);
-		else
-			sound (trp, CHAN_AUTO, "misc/bounce1.wav", 1, ATTN_NORM);
-					
-		float ostate = bouncee.state;
-		bouncee.maxbounce++;
-		bouncee.state = ostate | STATE_RM_BOUNCING;
-		activator = bouncee;
-		SUB_UseTargets();
-		bouncee.state = ostate;
-	}
-	self.nextthink = 0;
-}
-
 void() trampoline_touch =
 {
-		
-	// from Copper -- dumptruck_ds
-	if (!(CheckValidTouch() || (other.flags & FL_MONSTER || (other.movetype == MOVETYPE_BOUNCE && other.solid == SOLID_BBOX)) ))
-		return;
-	
-	vector up;
-	
-	traceline(other.origin + [0, 0, other.mins_z] , other.origin + [0, 0, other.mins_z] - '0 0 512', FALSE, other);
+	// Enforce a minimum velocity the player must fall so they won't just bounce endlessly
+	float minSpeed = -fabs(self.speed);
 
-	if (self.spawnflags & TRACE_TO_SURFACE)
+	// from Copper -- dumptruck_ds
+	if (!((other.flags & FL_MONSTER || (other.movetype == MOVETYPE_BOUNCE && other.solid == SOLID_BBOX))	
+	|| (CheckValidTouch()))) return;
+	
+	vector up = '0 0 1';
+	
+	if (self.spawnflags & TRACE_TO_SURFACE) {
+		vector offset = other.origin;
+		offset[2] -= 300;
+		traceline(other.origin, offset, FALSE, other);
 		up = trace_plane_normal;
-	else
-		up = '0 0 1';
+	}
 	
 	// Player doesn't take any fall damage when landing on a trampoline
 	other.cushion = self;
 	
-	// Set cushion sounds to be fired in PlayerPostThink
 	other.cushionnoise = self.noise2;
+	
 	other.cushionsounds = self.sounds;
 	
+	if(self.speed == -1) return; //Cushion only (no bounce)
 	
-	if (
-		other.velocity_z > -fabs(self.speed) // Enforce a minimum velocity the player must fall so they won't just bounce endlessly
-		|| self.speed == -1 // Cushion only (no bounce)
-	) 
-		return;
-
-	entity ctrl;
-
-	// setup bounce controller if not created yet
-	if (other.bouncecontroller.classname != "bouncecontroller") {
-		
-		ctrl = spawn();
-		other.bouncecontroller = ctrl;
-		ctrl.classname = "bouncecontroller";
-		ctrl.owner = other;
+	if (other.button2 || other.flags & FL_MONSTER || (other.movetype == MOVETYPE_BOUNCE && other.solid == SOLID_BBOX)) {
+	
+		if (other.velocity[2] < minSpeed) {
+			vector playervel = other.velocity;
+			// reflection equation
+			playervel = playervel - 2 * playervel * up * up * (self.elasticity);
+			
+			// if maxbounce is set, cap vertical movement speed at maxbounce
+			if (self.maxbounce > 0 && playervel[2] > self.maxbounce)
+				playervel[2] = self.maxbounce;
+			
+			other.velocity = playervel;
+			if (self.noise != "")
+				sound (self, CHAN_AUTO, self.noise, 1, ATTN_NORM);
+			else if (self.sounds == 1)
+				sound (self, CHAN_AUTO, "misc/bounce2.wav", 1, ATTN_NORM);
+			else if (self.sounds == 2)
+				sound (self, CHAN_AUTO, "misc/bounce3.wav", 1, ATTN_NORM);
+			else if (self.sounds == 3)
+				sound (self, CHAN_AUTO, "misc/bounce4.wav", 1, ATTN_NORM);
+			else if (self.sounds == 4)
+				sound (self, CHAN_AUTO, "misc/bounce5.wav", 1, ATTN_NORM);
+			else if (self.sounds == 5)
+				sound (self, CHAN_AUTO, "misc/bounce6.wav", 1, ATTN_NORM);
+			else
+				sound (self, CHAN_AUTO, "misc/bounce1.wav", 1, ATTN_NORM);
+				
+			//Fire trampoline targets on bounce
+			entity bouncee = other;
+			float ostate = bouncee.state;
+			bouncee.maxbounce++;
+			bouncee.state = ostate | STATE_RM_BOUNCING;
+			activator = other;
+			SUB_UseTargets();
+			bouncee.state = ostate;
+		}
 	}
-	// otherwise, just fetch a reference to the existing one
-	else
-		ctrl = other.bouncecontroller;
-
-	ctrl.enemy = self;
-
-	vector playervel = other.velocity;
 	
-	// calculates at which time the bounce will happen.
-	// 16u off the surface, so it's equivalent to the bounce point of the original code,
-	// but could theoretically set to 0
-	float timetobounce = fabs((trace_fraction*512 - 16)/other.velocity_z);
-
-	// calculates the downwards velocity the player will have at the bounce point, accounting for gravity
-	float grav = cvar("sv_gravity");
-	if (other.gravity) grav *= other.gravity;
-	playervel_z -= timetobounce * grav;
-
-	// reflection equation
-	// small correction factor for bounce velocity to be more or less consistent between jumps
-	playervel = playervel - 2 * playervel * up * up * self.elasticity + [0, 0, 6];
-	
-	// if maxbounce is set, cap vertical movement speed at maxbounce
-	if (self.maxbounce > 0 && playervel_z > self.maxbounce)
-		playervel_z = self.maxbounce;
-
-	ctrl.movedir = playervel;
-	ctrl.think = bouncecontroller_think;
-	ctrl.nextthink = time + timetobounce;
 }
 
-
-void() trigger_trampoline = {
+void() trigger_trampoline =
+{
 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
 		return;
 
 	InitTrigger ();
-	// stretches the trigger so it's at least 64u tall
-	if (self.size_z < 64)
-		setsize(self, self.mins, [self.maxs_x, self.maxs_y, self.mins_z + 64]);
-
 	precache_sound ("misc/bounce1.wav");
 	precache_sound ("misc/bounce2.wav");
 	precache_sound ("misc/bounce3.wav");
@@ -153,7 +104,7 @@ void() trigger_trampoline = {
 		
 	if (self.noise2 != "")
 		precache_sound(self.noise2);
-	
+		
 	self.touch = trampoline_touch;
 	if (!self.speed)
 		self.speed = 200;
@@ -164,7 +115,6 @@ void() trigger_trampoline = {
 	if (!self.maxbounce)
 		self.maxbounce = 0;
 };
-
 
 /*
 ===============================================================================

--- a/rm_mechanics.qc
+++ b/rm_mechanics.qc
@@ -52,7 +52,7 @@ void() bouncecontroller_think = {
 		fired = TRUE;
 	}
 	// this will always fire through the PlayerPostThink call
-	else if (bouncee.flags & FL_CLIENT /*&& (bouncee.jump_flag < -100)*/ && (bouncee.flags & FL_ONGROUND) && (bouncee.health > 0)) {
+	else if (bouncee.flags & FL_CLIENT && (bouncee.flags & FL_ONGROUND) && (bouncee.health > 0)) {
 		dprint4(bouncee.classname, " (", ftos(framecount), "): Cushioned\n");
 		if (trp.noise2 != "") sound(bouncee, CHAN_AUTO, trp.noise2, 1, ATTN_NORM);
 		else if (trp.sounds == 1) sound(bouncee, CHAN_AUTO, "misc/cushion2.wav", 1, ATTN_NORM);
@@ -177,6 +177,7 @@ void() trampoline_touch = {
 		other.velocity_z > -fabs(self.speed) // Enforce a minimum velocity the player must fall so they won't just bounce endlessly
 		|| self.speed == -1 // Cushion only (no bounce)
 	) {
+		//dprint4(other.classname, " (", ftos(framecount), "): low vertical speed, early out\n");
 		ctrl.movedir = '0 0 0';
 		return;
 	}
@@ -202,6 +203,7 @@ void() trampoline_touch = {
 
 	ctrl.movedir = playervel;
 	
+	dprint4(other.classname, " (", ftos(framecount), "): setting think\n");
 	ctrl.nextthink = time + timetobounce;
 }
 

--- a/rm_mechanics.qc
+++ b/rm_mechanics.qc
@@ -15,9 +15,12 @@ a higher boost that is not physically possible. Small changes in elasticity grea
 "maxbounce" The maximum vertical velocity that a player can achieve using the trampoline. Use of this is highly recommended if elasticity > 1, as otherwise the player will continue to gain upwards 
 speed indefinitely. Default of 0 means no limit.
 
+"punchangle" Defines a custom bounce angle. If unset, entities bounce in the direction of the face they hit.
+
 */
 
-float TRACE_TO_SURFACE = 1;
+//float TRACE_TO_SURFACE = 1; // deprecated
+float BOUNCE_ON_TOUCH = 2;
 
 void() bouncecontroller_think = {
 
@@ -33,8 +36,7 @@ void() bouncecontroller_think = {
 	
 	dprint6(bouncee.classname, " (", ftos(framecount), "): Bounce think, jump flag: ", ftos(bouncee.jump_flag), "\n");
 
-	if ((bouncee.button2 || bouncee.flags & FL_MONSTER || (bouncee.movetype == MOVETYPE_BOUNCE && bouncee.solid == SOLID_BBOX))
-		) {
+	if (bouncee.button2 || bouncee.flags & FL_MONSTER || (bouncee.movetype == MOVETYPE_BOUNCE && bouncee.solid == SOLID_BBOX)) {
 		bouncee.flags &~= FL_ONGROUND;
 		dprint6(bouncee.classname, " (", ftos(framecount), "): Bounced. Velocity ", vtos(self.movedir), "\n");
 		bouncee.velocity = self.movedir;
@@ -77,6 +79,7 @@ void() bouncecontroller_think = {
 		self = oself;
 
 		bouncee.state = ostate;
+		self.movedir = '0 0 0';
 	}
 	self.nextthink = 0;
 }
@@ -149,11 +152,15 @@ void() trampoline_touch = {
 		normal = trace_plane_normal;
 	}
 
-	//if (self.spawnflags & TRACE_TO_SURFACE)
-	up = normal;
-	//else
-	//	up = '0 0 1';
-	
+	if (self.punchangle != '0 0 0'){
+		makevectors([-self.punchangle_x, self.punchangle_y, self.punchangle_z]);
+		up = v_forward;
+	}
+	else if (self.spawnflags & BOUNCE_ON_TOUCH)
+		up = '0 0 1';
+	else
+		up = normal;
+		
 	// Player doesn't take any fall damage when landing on a trampoline
 	other.cushion = self;
 		
@@ -178,15 +185,23 @@ void() trampoline_touch = {
 		|| self.speed == -1 // Cushion only (no bounce)
 	) {
 		//dprint4(other.classname, " (", ftos(framecount), "): low vertical speed, early out\n");
-		ctrl.movedir = '0 0 0';
+		//ctrl.movedir = '0 0 0';
 		return;
 	}
 
 	vector playervel = other.velocity;
-	
+
+	float timetobounce;
+	float disttoplane = fraction*512;
+
 	// calculates at which time the bounce will happen.
 	// currently it's set to be at the surface and it works fine
-	float timetobounce = fabs(fraction*512/other.velocity_z);
+	if (self.spawnflags & BOUNCE_ON_TOUCH)
+		timetobounce = fabs((self.absmin_z + self.height - other.absmin_z)/other.velocity_z);
+	else
+		timetobounce = fabs(disttoplane/other.velocity_z);
+
+	
 
 	// calculates the downwards velocity the player will have at the bounce point, accounting for gravity
 	float grav = cvar("sv_gravity");
@@ -203,7 +218,7 @@ void() trampoline_touch = {
 
 	ctrl.movedir = playervel;
 	
-	dprint4(other.classname, " (", ftos(framecount), "): setting think\n");
+	dprint8(other.classname, " (", ftos(framecount), "): setting think ", ftos(timetobounce*1000), "ms ahead. Velocity to set: ", vtos(playervel), "\n");
 	ctrl.nextthink = time + timetobounce;
 }
 
@@ -216,6 +231,7 @@ void() trigger_trampoline = {
 	// stretches the trigger upwards so it's at least 48u tall
 	// 48 is enough to catch an entity falling 1500ups downwards at 30fps
 	// taller than that risks making the trigger to fire when it's not supposed to
+	self.height = self.size_z;
 	if (self.size_z < 48)
 		setsize(self, self.mins, [self.maxs_x, self.maxs_y, self.mins_z + 48]);
 

--- a/rm_mechanics.qc
+++ b/rm_mechanics.qc
@@ -340,6 +340,11 @@ void() trigger_trampoline = {
 	if (self.size_z < 48)
 		setsize(self, self.mins, [self.maxs_x, self.maxs_y, self.mins_z + 48]);
 
+	if (mapname == "rm_heretics") {
+		dprint("rm_heretics found. Turning on the Bounce on Touch and No Bounds Check flags for all trampolines\n");
+		self.spawnflags |= BOUNCE_ON_TOUCH + BOUNCE_NO_BOUNDS_CHECK;
+	}
+
 	precache_sound ("misc/bounce1.wav");
 	precache_sound ("misc/bounce2.wav");
 	precache_sound ("misc/bounce3.wav");

--- a/rm_mechanics.qc
+++ b/rm_mechanics.qc
@@ -98,18 +98,7 @@ void() trampoline_touch = {
 	
 	// Player doesn't take any fall damage when landing on a trampoline
 	other.cushion = self;
-	
-	// Set cushion sounds to be fired in PlayerPostThink
-	other.cushionnoise = self.noise2;
-	other.cushionsounds = self.sounds;
-	
-	
-	if (
-		other.velocity_z > -fabs(self.speed) // Enforce a minimum velocity the player must fall so they won't just bounce endlessly
-		|| self.speed == -1 // Cushion only (no bounce)
-	) 
-		return;
-
+		
 	entity ctrl;
 
 	// setup bounce controller if not created yet
@@ -125,6 +114,14 @@ void() trampoline_touch = {
 		ctrl = other.bouncecontroller;
 
 	ctrl.enemy = self;
+
+	if (
+		other.velocity_z > -fabs(self.speed) // Enforce a minimum velocity the player must fall so they won't just bounce endlessly
+		|| self.speed == -1 // Cushion only (no bounce)
+	) {
+		ctrl.movedir = '0 0 0';
+		return;
+	}
 
 	vector playervel = other.velocity;
 	

--- a/utility.qc
+++ b/utility.qc
@@ -216,3 +216,16 @@ void stuffcmd_float( entity client, float f) =
 	decpart = decpart * 10000;
 	stuffcmd_int( client, decpart, 10000);
 }
+
+
+
+float(vector point, vector minbox, vector maxbox) checkbounds = {
+	if (!(point_x >= minbox_x && point_x <= maxbox_x))
+		return FALSE;
+	if (!(point_y >= minbox_y && point_y <= maxbox_y))
+		return FALSE;
+	if (!(point_z >= minbox_z && point_z <= maxbox_z))
+		return FALSE;
+	
+	return TRUE;
+};


### PR DESCRIPTION
New trampoline code based on timers to simulate a bounce closer to the surface, no matter the trigger height. This way you can make them taller to better catch falling entities.

- Triggers get automatically resized to be at least 64u tall, so no further changes are needed for current maps. Fixes issue with entities failing to bounce depending on fall speed, trigger height and framerate;
- Velocity across multiple bounces is more consistent given a set height;
- "angled" spawnflag deprecated, all trampolines act as angled now. You always bounce at the surface you actually hit, in the direction of the surface, and the trigger can cover the whole ramp if it's the case;
- New "bounce on touch" spawnflag, makes entities bounce when they hit the top of the trigger instead of at the face below, and always in a straight upwards angle. Useful when the world surface underneath is bumpy and irregular. This makes trampolines work more or less like the old code, but without the missed bounces bug;
- New "punchangle" field lets you override the bounce angle;
- More precise bounds check for when inside the trigger - you don't if you hit some heightened border around the trampoline for example.