### PR TITLE
Push speed

### DIFF
--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -302,10 +302,17 @@ count(integer) : "How many monsters to spawn (default 5)"
 @PointClass base(PlayerClass) = info_player_start2 : "Player episode return point" []
 @PointClass base(PlayerClass) = info_player_deathmatch : "Deathmatch start" []
 @PointClass base(PlayerClass) = testplayerstart : "Testing player start" []
-@PointClass size(-32 -32 0, 32 32 64) base(PlayerClass, Targetname) = info_teleport_destination : "Teleporter destination" []
+@PointClass size(-32 -32 0, 32 32 64) base(PlayerClass, Targetname) = info_teleport_destination : "Teleporter destination"
+[
+	speed(integer) : "Push speed" : 300
+]
 @PointClass size(-32 -32 0, 32 32 64) base(PlayerClassAlt, Targetname) = info_teleport_random : "Random Teleporter destination
 
-Only for use with trigger_teleport entities set to RANDOM" []
+Only for use with trigger_teleport entities set to RANDOM"
+[
+	speed(integer) : "Push speed" : 300
+]
+
 @PointClass color(200 150 150) = info_null : "info_null (spotlight target)"
 [
 	targetname(target_source) : "Name"

--- a/triggers.qc
+++ b/triggers.qc
@@ -554,6 +554,9 @@ local vector	org;
 
 		if (!t)
 			objerror ("couldn't find target");
+			
+		float dest_speed = t.speed;
+		if(!dest_speed) dest_speed = 300; //Default push speed at destination
 
 // // put a tfog where the player was
 // 	spawn_tfog (other.origin);
@@ -590,7 +593,7 @@ if (!(self.spawnflags & TELE_STEALTH))
 		other.teleport_time = time + 0.7;
 		if (other.flags & FL_ONGROUND)
 			other.flags = other.flags - FL_ONGROUND;
-		other.velocity = v_forward * 300;
+		other.velocity = v_forward * dest_speed;
 	}
 	other.flags = other.flags - other.flags & FL_ONGROUND;
 
@@ -600,7 +603,7 @@ if (!(self.spawnflags & TELE_STEALTH))
 		other.teleport_time = time + 0.7;
 		if (other.flags & FL_ONGROUND)
 			other.flags = other.flags - FL_ONGROUND;
-		other.velocity = v_forward * 300;
+		other.velocity = v_forward * dest_speed;
 	}
 	other.flags = other.flags - other.flags & FL_ONGROUND;
 };


### PR DESCRIPTION
info_teleport_destination & info_teleport_random now support the new .speed property (defaults to the usual 300).
That's the velocity at which the player is pushed at destination.
Set it to a non-zero but close-to-zero value (like 0.001) for no speed at destination.
Can take a negative value for backward speed if that makes sense.
