### PR TITLE
Ordered counter

### DIFF
--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -2769,7 +2769,12 @@ If needed, the ammo values are cut off to always stay in the legal [0..100] rang
 	height(integer) : "Jump Height" : 200
 	spawnflags(flags) = [ 8: "Start Off (toggles)" : 0 ] //dumptruck_ds
 ]
-@PointClass base(Appearflags, Target, Targetname) = trigger_counter : "Trigger: Counter"
+@PointClass base(Appearflags, Target, Targetname) = trigger_counter : "Trigger: Counter
+
+To make it ordered, give the entities firing it an order index (starting from 1) in their .aflag property
+An ordered counter is always reset for a new try when the sequence is completed in the wrong order. In that situation, if the entities targeting it are func_buttons, they're returned to their initial state for a new attempt.
+Don't forget that buttons targeting a counter should always be wait|-1 anyway, no matter the counter is ordered or not.
+"
 [
 	spawnflags(flags) = [
 		1: "No Message" : 0
@@ -2777,7 +2782,9 @@ If needed, the ammo values are cut off to always stay in the legal [0..100] rang
 	]
 	count(integer) : "Count before trigger" : 2
 	delay (integer) : "Delay"
-	message(string) : "Message"
+	message(string) : "Message when sequence completed"
+	message2(string) : "Message when sequence completed in the wrong order"
+	pain_target(string) : "Fire this target when sequence completed in the wrong order"
 ]
 @SolidClass base(Angle, Appearflags, Targetname, TriggerWait) = trigger_push : "Trigger: Push"
 [

--- a/triggers.qc
+++ b/triggers.qc
@@ -262,7 +262,17 @@ void() trigger_secret =
 };
 
 //=============================================================================
-
+void counter_return_buttons (.string targetfield, string targetname)
+{
+	for (entity e = world; (e = find(e, targetfield, targetname)); )
+	{
+		if (e.classname == "func_button")
+		{
+			e.think = button_return;
+			e.nextthink = e.ltime + 1;
+		}
+	}
+}
 
 void() counter_use =
 {
@@ -272,6 +282,10 @@ void() counter_use =
 	if (self.count < 0)
 		return;
 
+	self.cnt += 1;
+	if (other.aflag > 0 && other.aflag != self.cnt) 
+	  self.items = 1; //Wrong order
+	
 	/**/
 	entity msgEnt = world;
 	if (activator.classname == "player" && (self.spawnflags & SPAWNFLAG_NOMESSAGE) == 0)
@@ -297,9 +311,46 @@ void() counter_use =
 	}
 
 	if (msgEnt)
-		centerprint(msgEnt, "Sequence completed!");
+	{
+		if(self.items == 0 && self.message != "")
+			centerprint(msgEnt, self.message);
+		else if(self.items == 0)
+			centerprint(msgEnt, "Sequence completed!");
+		else if(self.message2 != "")
+			centerprint(msgEnt, self.message2);
+		else
+			centerprint(msgEnt, "Wrong sequence");
+	}
 	self.enemy = activator;
-	multi_trigger ();
+	if(self.items == 0)
+		multi_trigger ();
+	else
+	{
+		SUB_UsePain2();
+		
+		//Get ready for the next try
+		self.cnt = 0;
+		self.count = self.frags;
+		self.items = 0;
+		
+		//Return buttons to initial state
+		counter_return_buttons(target,self.targetname);
+		counter_return_buttons(target,self.targetname2);
+		counter_return_buttons(target,self.targetname3);
+		counter_return_buttons(target,self.targetname4);
+		counter_return_buttons(target2,self.targetname);
+		counter_return_buttons(target2,self.targetname2);
+		counter_return_buttons(target2,self.targetname3);
+		counter_return_buttons(target2,self.targetname4);
+		counter_return_buttons(target3,self.targetname);
+		counter_return_buttons(target3,self.targetname2);
+		counter_return_buttons(target3,self.targetname3);
+		counter_return_buttons(target3,self.targetname4);
+		counter_return_buttons(target4,self.targetname);
+		counter_return_buttons(target4,self.targetname2);
+		counter_return_buttons(target4,self.targetname3);
+		counter_return_buttons(target4,self.targetname4);
+	}
 };
 
 /*QUAKED trigger_counter (.5 .5 .5) ? nomessage X X X X X X X NOT_ON_EASY NOT_ON_NORMAL NOT_ON_HARD_OR_NIGHTMARE NOT_IN_DEATHMATCH NOT_IN_COOP NOT_IN_SINGLEPLAYER X NOT_ON_HARD_ONLY NOT_ON_NIGHTMARE_ONLY
@@ -319,6 +370,11 @@ void() trigger_counter =
 	if (!self.count)
 		self.count = 2;
 
+	//Used when caring for the order
+	self.items = 0;
+	self.cnt = 0;
+	self.frags = self.count;
+	
 	self.use = counter_use;
 };
 


### PR DESCRIPTION
Evolution of the good old trigger_counter to make it optionally ordered.
* Target a trigger_counter the way you'd normally do
* Give the entities targeting it a unique aflag value which is their order #, starting from 1 (1, 2, 3, etc.)
* When the trigger has been fired the required amount of times, what happens depends on whether the expected order was respected...
* If yes, targets are fired the usual way
* If no, targets matching the entity's pain_target property are fired (or, if no pain_target, there's just a message saying "wrong sequence").
* If the sequence was wrong, all entities of type "func_button" targeting the counter are reset in waiting state.
(Make sure to make them wait|-1 anyway as usual, so that the same button can't count more than once)