### PR TITLE
Uncomment precaches for gib2 & 3

### DIFF
--- a/demon.qc
+++ b/demon.qc
@@ -286,8 +286,8 @@ void() monster_demon1 =
 	precache_sound_sight ("demon/sight2.wav");
 
   precache_gib1 ("progs/gib1.mdl");
-  // precache_gib2 ("progs/gib2.mdl");
-  // precache_gib3 ("progs/gib3.mdl");
+  precache_gib2 ("progs/gib2.mdl");
+  precache_gib3 ("progs/gib3.mdl");
 
 	self.solid = SOLID_SLIDEBOX;
 	self.movetype = MOVETYPE_STEP;


### PR DESCRIPTION
For some reason, when gibbed a demon throws only progs/gib1.mdl gib models.
That's a weirdness dating back to the original Quake game. They're not the only monster with a similar weirdness.
Monsters throwing only 1 type of gibs are:
* demon
* dog
* fish
* ogre
* wizard

Anyway, the specificity of demon is that, presumably for the reason explained above, someone at some point supposed precache_gib2 and precache_gib3 were useless, which was wrong. Indeed, if a mapper wishes to customize the gibs #2 and #3, those need to be precached as well.
The issue was encountered by Jamaeson:
![image](https://github.com/EmeraldTiger/Re-Mobilize/assets/72394209/3357cc12-c731-4ef5-80bf-e4317907dd9a)

This PR restores the precaches to allow custom gibs, while not modifying the weird vanilla core default behavior.