### PR TITLE
DroptStuff now supporting drop_item 7

### DIFF
--- a/items.qc
+++ b/items.qc
@@ -2436,6 +2436,11 @@ void() DropStuff =
 				DropVial();
 			}
 	}
+	else if (self.drop_item == 7)
+	{
+		entity k = find(world,targetname,self.target);
+		if(k) k.origin = self.origin + '0 0 24';
+	}
 	return;
 };
 


### PR DESCRIPTION
Value 7 for drop_item in the DroptStuff function was not supported, and therefore not consistent with the monster_death_use function.