### PR TITLE
Remove monsters: fix kill count/total count

### DIFF
--- a/subs.qc
+++ b/subs.qc
@@ -390,7 +390,11 @@ void() SUB_UseTargets =
 		{
 			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "m");
 			if(t.enemy != world && t.enemy.suppressCenterPrint == TRUE) t.enemy.suppressCenterPrint = FALSE;
-			if(t.flags & FL_MONSTER) monster_update_total (-1);
+			if(t.flags & FL_MONSTER && t.health > 0)
+			{
+				killed_monsters = killed_monsters + 1;
+				WriteByte (MSG_ALL, SVC_KILLEDMONSTER);
+			}
 			remove(t);
 			t = find(t, targetname, self.killtarget);
 		}
@@ -399,7 +403,11 @@ void() SUB_UseTargets =
 		{
 			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "m");
 			if(t.enemy != world && t.enemy.suppressCenterPrint == TRUE) t.enemy.suppressCenterPrint = FALSE;
-			if(t.flags & FL_MONSTER) monster_update_total (-1);
+			if(t.flags & FL_MONSTER && t.health > 0)
+			{
+				killed_monsters = killed_monsters + 1;
+				WriteByte (MSG_ALL, SVC_KILLEDMONSTER);
+			}
 			remove(t);
 			t = find(t, targetname2, self.killtarget);
 		}
@@ -408,7 +416,11 @@ void() SUB_UseTargets =
 		{
 			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "m");
 			if(t.enemy != world && t.enemy.suppressCenterPrint == TRUE) t.enemy.suppressCenterPrint = FALSE;
-			if(t.flags & FL_MONSTER) monster_update_total (-1);
+			if(t.flags & FL_MONSTER && t.health > 0)
+			{
+				killed_monsters = killed_monsters + 1;
+				WriteByte (MSG_ALL, SVC_KILLEDMONSTER);
+			}
 			remove(t);
 			t = find(t, targetname3, self.killtarget);
 		}
@@ -417,7 +429,11 @@ void() SUB_UseTargets =
 		{
 			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "m");
 			if(t.enemy != world && t.enemy.suppressCenterPrint == TRUE) t.enemy.suppressCenterPrint = FALSE;
-			if(t.flags & FL_MONSTER) monster_update_total (-1);
+			if(t.flags & FL_MONSTER && t.health > 0)
+			{
+				killed_monsters = killed_monsters + 1;
+				WriteByte (MSG_ALL, SVC_KILLEDMONSTER);
+			}
 			remove(t);
 			t = find(t, targetname4, self.killtarget);
 		}
@@ -433,7 +449,11 @@ void() SUB_UseTargets =
 		{
 			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "m");
 			if(t.enemy != world && t.enemy.suppressCenterPrint == TRUE) t.enemy.suppressCenterPrint = FALSE;
-			if(t.flags & FL_MONSTER) monster_update_total (-1);
+			if(t.flags & FL_MONSTER && t.health > 0)
+			{
+				killed_monsters = killed_monsters + 1;
+				WriteByte (MSG_ALL, SVC_KILLEDMONSTER);
+			}
 			remove(t);
 			t = find(t, targetname, self.killtarget2);
 		}
@@ -442,7 +462,11 @@ void() SUB_UseTargets =
 		{
 			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "m");
 			if(t.enemy != world && t.enemy.suppressCenterPrint == TRUE) t.enemy.suppressCenterPrint = FALSE;
-			if(t.flags & FL_MONSTER) monster_update_total (-1);
+			if(t.flags & FL_MONSTER && t.health > 0)
+			{
+				killed_monsters = killed_monsters + 1;
+				WriteByte (MSG_ALL, SVC_KILLEDMONSTER);
+			}
 			remove(t);
 			t = find(t, targetname2, self.killtarget2);
 		}
@@ -451,7 +475,11 @@ void() SUB_UseTargets =
 		{
 			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "m");
 			if(t.enemy != world && t.enemy.suppressCenterPrint == TRUE) t.enemy.suppressCenterPrint = FALSE;
-			if(t.flags & FL_MONSTER) monster_update_total (-1);
+			if(t.flags & FL_MONSTER && t.health > 0)
+			{
+				killed_monsters = killed_monsters + 1;
+				WriteByte (MSG_ALL, SVC_KILLEDMONSTER);
+			}
 			remove(t);
 			t = find(t, targetname3, self.killtarget2);
 		}
@@ -460,7 +488,11 @@ void() SUB_UseTargets =
 		{
 			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "m");
 			if(t.enemy != world && t.enemy.suppressCenterPrint == TRUE) t.enemy.suppressCenterPrint = FALSE;
-			if(t.flags & FL_MONSTER) monster_update_total (-1);
+			if(t.flags & FL_MONSTER && t.health > 0)
+			{
+				killed_monsters = killed_monsters + 1;
+				WriteByte (MSG_ALL, SVC_KILLEDMONSTER);
+			}
 			remove(t);
 			t = find(t, targetname4, self.killtarget2);
 		}


### PR DESCRIPTION

![image](https://github.com/EmeraldTiger/Re-Mobilize/assets/72394209/851bbfb8-86f4-4044-a43f-542cc28df750)

flecked's playthrough in rm_waterfront proved the previous implementation to be wrong because it wasn't considering whether a removed monster was still alive or not. This new implementation does.
Moreover, following a discussion with bmFbr, it appears to be certainly better if monsters aren't removed (decremented from total count) but credited to the kill count instead (even if discarded by means of map events and not direct player hits).