### PR TITLE
Target_setstate enhanced

### DIFF
--- a/client.qc
+++ b/client.qc
@@ -925,19 +925,22 @@ void() CheckGrapple =
 
 }
 
-void(float makeSolid) MakePlayerClipSolid =
+void(string clname, float makeSolid) MakeClassSolid =
 {
     entity e = world;
-	entity oself = self;
-    while( (e = find(e, classname, "func_playerclip")) )
+    while( (e = find(e, classname, clname)) )
     {
-		if(e.estate != makeSolid)
+		if(makeSolid == TRUE)
 		{
-			self = e;
-			self.use();
-        }
+			e.solid = SOLID_BSP;
+			e.movetype = MOVETYPE_PUSH;
+		}
+		else
+		{
+			e.solid = SOLID_NOT;
+			e.movetype = MOVETYPE_NONE;
+		}
     }
-	self = oself;
 };
 
 /*
@@ -1010,7 +1013,8 @@ void() PlayerPreThink =
 	if (cleanUpClientStuff)
 		fog_setFromEnt(self, self);
 
-	MakePlayerClipSolid(TRUE);
+	MakeClassSolid("func_playerclip",TRUE);
+	MakeClassSolid("func_playernoclip",FALSE);
 	
 	makevectors (self.v_angle);		// is this still used
 
@@ -1417,7 +1421,8 @@ void() PlayerPostThink =
 	if (self.deadflag)
 		return;
 
-	MakePlayerClipSolid(FALSE);
+	MakeClassSolid("func_playerclip",FALSE);
+	MakeClassSolid("func_playernoclip",TRUE);
 	
 // do weapon stuff
 

--- a/client.qc
+++ b/client.qc
@@ -1217,7 +1217,8 @@ else
 		CheckWaterJump ();
 	
 	//Display custom keys inventory
-	if(invPanel) invPanel.origin = self.origin + v_forward*(250) + v_up*(100);
+	if(invPanel) invPanel.origin = self.origin + v_forward*250 + v_up*100;
+	if(invEmpty) invEmpty.origin = self.origin + v_forward*200 + v_up*55;
 	if(self.skip_id1_overrides > 0)
 	{
 		float dist = world.distance;

--- a/defs.qc
+++ b/defs.qc
@@ -882,7 +882,6 @@ void() SUB_UsePain; //dumptruck_ds
 .float color; //Hipnotic
 .float megahealth_rottime; // dumptruck_ds
 .float alpha; // from RennyC func_fall in dtmisc.qc
-.float ltrailLastUsed;  //from DOE lighnin
 .float style2; //c0burn's switchable lights
 .float sight_trigger; //dumptruck_ds
 .float keep_ammo; //dumptruck_ds

--- a/defs.qc
+++ b/defs.qc
@@ -1119,7 +1119,7 @@ void(entity client, float density, vector color) csf_set;
 .float visitflag;
 
 //Inky 20221210 Custom keys inventory
-entity invPanel, invItem1, invItem2, invItem3, invItem4, invItem5, invLabel1, invLabel2, invLabel3, invLabel4, invLabel5;
+entity invPanel, invEmpty, invItem1, invItem2, invItem3, invItem4, invItem5, invLabel1, invLabel2, invLabel3, invLabel4, invLabel5;
 .string face_always;
 
 //Inky 20230407 External validator

--- a/doelightning.qc
+++ b/doelightning.qc
@@ -2,8 +2,6 @@
 // pmack
 // sept 96
 
-// float ltrailLastUsed;		-- now an entity field.
-
 float LT_TOGGLE =	1;
 float LT_ACTIVE = 	2;
 
@@ -74,13 +72,7 @@ void() ltrail_start_fire =
 			return;
 	}
 
-	if (self.classname ==  "ltrail_start")
-	{
-		self.items = time + self.weapon;
-		ltrail_fire();
-		self.ltrailLastUsed = time;
-	}
-	else if (self.classname == "ltrail_relay")
+	if (self.classname ==  "ltrail_start" || self.classname == "ltrail_relay")
 	{
 		self.items = time + self.weapon;
 		ltrail_fire();
@@ -110,8 +102,6 @@ void() ltrail_start =
 {
 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
 		return;
-
-	self.ltrailLastUsed = time;
 
 	precache_sound ("weapons/lhit.wav");
 	self.movetype = MOVETYPE_NONE;

--- a/doors.qc
+++ b/doors.qc
@@ -806,7 +806,7 @@ void () fd_secret_use =
 
 	self.dest2 = self.dest1 + v_forward * (self.t_length - self.lip);
 	SUB_CalcMove(self.dest1, self.speed, fd_secret_move1);
-	sound(self, CHAN_VOICE, self.noise2, 1, ATTN_NORM);
+	if (self.noise3 != "0") sound(self, CHAN_VOICE, self.noise2, 1, ATTN_NORM);
 };
 
 void(entity attacker, float damage) fd_secret_pain = { fd_secret_use(); };
@@ -817,7 +817,7 @@ void () fd_secret_move1 =
 	self.state = /*Half way*/1;
 	self.nextthink = self.ltime + 1.0;
 	self.think = fd_secret_move2;
-	sound(self, CHAN_VOICE, self.noise3, 1, ATTN_NORM);
+	if (self.noise3 != "0") sound(self, CHAN_VOICE, self.noise3, 1, ATTN_NORM);
 };
 
 // Start moving sideways w/sound...
@@ -831,7 +831,7 @@ void () fd_secret_move2 =
 void () fd_secret_move3 =
 {
 	self.state = /*Open*/2;
-	sound(self, CHAN_VOICE, self.noise3, 1, ATTN_NORM);
+	if (self.noise3 != "0") sound(self, CHAN_VOICE, self.noise3, 1, ATTN_NORM);
 	if (!(self.spawnflags & SECRET_OPEN_ONCE))
 	{
 		self.nextthink = self.ltime + self.wait;
@@ -852,12 +852,12 @@ void () fd_secret_move5 =
 	self.state = /*Half way back*/3;
 	self.nextthink = self.ltime + 1.0;
 	self.think = fd_secret_move6;
-	sound(self, CHAN_VOICE, self.noise3, 1, ATTN_NORM);
+	if (self.noise3 != "0") sound(self, CHAN_VOICE, self.noise3, 1, ATTN_NORM);
 };
 
 void () fd_secret_move6 =
 {
-	sound(self, CHAN_VOICE, self.noise2, 1, ATTN_NORM);
+	if (self.noise3 != "0") sound(self, CHAN_VOICE, self.noise2, 1, ATTN_NORM);
 	SUB_CalcMove(self.oldorigin, self.speed, fd_secret_done);
 };
 
@@ -870,7 +870,10 @@ void () fd_secret_done =
 		self.takedamage = DAMAGE_YES;
 		self.th_pain = fd_secret_pain;
 	}
-	sound(self, CHAN_VOICE, self.noise3, 1, ATTN_NORM);
+	if (self.noise3 == "0")
+		sound(self, CHAN_VOICE, self.noise1, 1, ATTN_NORM);
+	else
+		sound(self, CHAN_VOICE, self.noise3, 1, ATTN_NORM);
 };
 
 void () secret_blocked =
@@ -929,6 +932,8 @@ If a secret door has a targetname, it will only be opened by it's botton or trig
 
 void () func_door_secret =
 {
+	local string default_noise1, default_noise2, default_noise3;
+
 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
 		return;
 
@@ -936,29 +941,28 @@ void () func_door_secret =
 		self.sounds = 3;
 	if (self.sounds == 1)
 	{
-		precache_sound ("doors/latch2.wav");
-		precache_sound ("doors/winch2.wav");
-		precache_sound ("doors/drclos4.wav");
-		self.noise1 = "doors/latch2.wav";
-		self.noise2 = "doors/winch2.wav";
-		self.noise3 = "doors/drclos4.wav";
+		default_noise1 = "doors/latch2.wav";
+		default_noise2 = "doors/winch2.wav";
+		default_noise3 = "doors/drclos4.wav";
 	}
 	if (self.sounds == 2)
 	{
-		precache_sound ("doors/airdoor1.wav");
-		precache_sound ("doors/airdoor2.wav");
-		self.noise2 = "doors/airdoor1.wav";
-		self.noise1 = "doors/airdoor2.wav";
-		self.noise3 = "doors/airdoor2.wav";
+		default_noise1 = "doors/airdoor2.wav";
+		default_noise2 = "doors/airdoor1.wav";
+		default_noise3 = "doors/airdoor2.wav";
 	}
 	if (self.sounds == 3)
 	{
-		precache_sound ("doors/basesec1.wav");
-		precache_sound ("doors/basesec2.wav");
-		self.noise2 = "doors/basesec1.wav";
-		self.noise1 = "doors/basesec2.wav";
-		self.noise3 = "doors/basesec2.wav";
+		default_noise1 = "doors/basesec2.wav";
+		default_noise2 = "doors/basesec1.wav";
+		default_noise3 = "doors/basesec2.wav";
 	}
+	if(self.noise1 == "") self.noise1 = default_noise1; //Secret door start noise
+	if(self.noise2 == "") self.noise2 = default_noise2; //Secret door move noise
+	if(self.noise3 == "") self.noise3 = default_noise3; //secret door stop noise
+	precache_sound (self.noise1);
+	precache_sound (self.noise2);
+	precache_sound (self.noise3);
 
 	if (!self.dmg)
 		self.dmg = 2;

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -1864,6 +1864,8 @@ Also, the state of the last evaluation is stored in this entity's 'state' field 
 		5 : "& (bitwise AND, valid for floats and flags)"
 		6 : "| (bitwise OR, valid for floats and flags)"
 		7 : "% (remainder of an integer division, valid for floats and flags)"
+		8 : "!= (not equal, valid for all fields)"
+		9 : "!& (bitwise AND returns false, valid for floats and flags)"
 	]
 	count(integer) : "Float value to test"
 	cnt(integer) : "Modulus used for the % operator"

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -1442,7 +1442,7 @@ spawnflags(Flags) =
 // misc
 //
 
-@SolidClass base(Appearflags, ModelLight) = func_illusionary : "Static nonsolid model"  []
+@SolidClass base(Appearflags, ModelLight) = func_illusionary : "Static nonsolid model"  [ targetname(target_source) : "Name" : : "Useful for stealth teleportation only (see wiki)"]
 
 @PointClass base(Appearflags) color(0 150 220) model({ "path": ":progs/s_bubble.spr" }) = air_bubbles : "Air bubbles" []
 @PointClass base(Appearflags, Targetname) = event_lightning : "Chthon's lightning"

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -3654,7 +3654,13 @@ sounds(integer) : "Track Number (ex 02->xx)" :  : "CD track or audio file to pla
 @PointClass base(Appearflags, Targetname) size(-8 -8 -8, 8 8 8) color(200 128 0) = trigger_cdtrack : "Trigger that changes the currently playing music track. The number of the track to play goes in the count key." [
     count(integer) : "Track Number (ex 02->xx)" :  : "CD track or audio file to play from within music folder"
 ]
-@SolidClass base(Appearflags, Trigger, Target, TriggerWait, FilterTouch) = trigger_look : "Trigger: Trigger something when a player enters this volume and looks directly at a targeted brush entity. Use the first target key for the looked at item and subsequent targets to trigger events. Add a wait key to make this a trigger_multiple"
+@SolidClass base(Appearflags, Trigger, Target, TriggerWait, FilterTouch) = trigger_look : "Trigger: Trigger something when a player enters this volume and either
+* looks directly at a targeted brush entity
+* has a clear line of sight to a targeted brush entity even if not looking at it
+otherwise, trigger the pain_target(s), if any.
+
+Use the first target key for the looked at item and subsequent targets to trigger events. Add a wait key to make this a trigger_multiple.
+"
 [
 	speed(integer) : "Distance from player to search for trigger, adjust if the target is too far from the trigger" : 500
 	wait(integer) : "Time between re-triggering"
@@ -3667,6 +3673,11 @@ sounds(integer) : "Track Number (ex 02->xx)" :  : "CD track or audio file to pla
 		4 : "Custom sound, requires a path set in noise1 key"
 	]
 	noise1(string) : "Path to custom sound. Use with sounds key set to 4"
+	spawnflags(Flags) =
+	[
+		1 : "Line of sight" : 0 : "A clear line of sight exists, no matter the distance or the player's looking direction"
+	]
+	pain_target(string) : "Target(s) to fire when the looking/los check fails"
 ]
 //item-backpack
 @PointClass base(Appearflags, OneTargetname, Effects) size(-16 -16 0, 16 16 56) color(80 0 200)  model(

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -2035,6 +2035,9 @@ Originally unused in the game. Plays the sound of thunder at a random interval. 
 		2: "Metal"
 		3: "Base"
 	]
+	noise1(string) : "Custom start noise"
+	noise2(string) : "Custom move noise"
+	noise3(string) : "Custom stop noise" : : "If set to '0', no stop noise is played, allowing noise2 to go on without being interrupted halfway."
 	message(string) : "Message"
 	spawnflags(flags) =
 	[

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -3138,11 +3138,11 @@ NOTE - Sound files must be in the SOUND folder (or a sub folder under the SOUND 
 
 		noise(string) : "Sound file to play"
 		speed(choices) : "Attenuation of sound" : 1 =
-				[
+		[
 			-1 : "No attenuation (heard everywhere)"
-			1  : "Normal"
-			2  : "Idle"
-			3  : "Static"
+			1  : "Normal (fades to zero at 1000 units)"
+			2  : "Idle (fades to zero at 512 units)"
+			3  : "Static (fades to zero at 341 units)"
 		]
 		volume(integer) : "Volume (0 - 1)" : 1
 		impulse(integer) : "Channel (0 - 7) Automatic" : 0
@@ -3168,9 +3168,9 @@ NOTE - Sound files must be in the SOUND folder (or a sub folder under the SOUND 
 		speed(choices) : "Attenuation of sound" : 1 =
 		[
 			-1 : "No attenuation (heard everywhere)"
-			1  : "Normal"
-			2  : "Idle"
-			3  : "Static"
+			1  : "Normal (fades to zero at 1000 units)"
+			2  : "Idle (fades to zero at 512 units)"
+			3  : "Static (fades to zero at 341 units)"
 		]
 		volume(integer) : "Volume (0 - 1)" : 1
 		impulse(integer) : "Channel (0 - 7) Automatic" : 0
@@ -3186,11 +3186,11 @@ NOTE - Sound files must be in the SOUND folder (or a sub folder under the SOUND 
 	[
 		noise(string) : "Sound file to play"
 		speed(choices) : "Attenuation of sound" : 1 =
-				[
+		[
 			-1 : "No attenuation (heard everywhere)"
-			1  : "Normal"
-			2  : "Idle"
-			3  : "Static"
+			1  : "Normal (fades to zero at 1000 units)"
+			2  : "Idle (fades to zero at 512 units)"
+			3  : "Static (fades to zero at 341 units)"
 		]
 		volume(integer) : "Volume (0 - 1)" : 1
 	]

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -1845,7 +1845,7 @@ Also, the state of the last evaluation is stored in this entity's 'state' field 
 		5 : "classname (string, use 'type' field)"
 		6 : "estate (float, use 'count' field)"
 		8 : "targetname (string, use 'type' field; set shardvalue to 2-4 for targetname2-targetname4)"
-		10 : "items (flag, use 'aflags' field)"
+		10 : "items (flag, use 'aflag' field)"
 		11 : "count (float, use 'count' field)"
 		12 : "cnt (float, use 'count' field)"
 		13 : "type (string, use 'type' field)"

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -489,7 +489,7 @@ the bprint tends to stomp any other prints on screen in most quake clients, so u
 ]
 
 @BaseClass base(RespawnableItem, CustomMdlsAmmo, CustomMdlsSkin) size(-16 -16 -24, 16 16 32) =
-	Artifact []
+	Artifact [ netname(string) : "Custom name for the artifact when picked up" ]
 
 @PointClass base(Artifact) model({ "path": ":progs/suit.mdl" }) =
 	item_artifact_envirosuit : "Environmental protection suit" []

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -551,8 +551,13 @@ the bprint tends to stomp any other prints on screen in most quake clients, so u
 	obit_name(string) : "Custom name for this armor." : : "Set a custom name for your armor. Just complete the sentence `You got` e.g. the Mega Armor! for `You got the Mega Armor!'"
 	]
 
-@BaseClass base(NonRespawnableItem) size(-16 -16 -24, 16 16 32) =
-	Key []
+@BaseClass base(NonRespawnableItem) size(-16 -16 -24, 16 16 32) = Key
+[
+	spawnflags(flags) =
+	[
+		2097152 : "Silent pickup" : 0 : "Programmatically add the item to the player's inventory"
+	]
+]
 
 // @PointClass base(Key) model({ "path": ":progs/w_s_key.mdl" }) =
 @PointClass base(Key, CustomMdlsSkin) model(

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -3991,7 +3991,13 @@ Example: 3 targets of impulse respectively 3, 2 and 1 --> Total cumulated impuls
 	killtarget2(target_destination) : "Killtarget2 (fired upon leaving the trigger)"
 ]
 
-@SolidClass base(Appearflags, Targetname) = func_playerclip : "A bbox entity which is solid for the player only" []
+@SolidClass base(Appearflags, Targetname) = func_playerclip : "A bbox entity which is solid for the player only
+
+Caution! It's not solid for monsters and the rest of the world, tho! For them, it has no blocking characteristics (they can freely see/pass through it)" []
+
+@SolidClass base(Appearflags, Targetname) = func_playernoclip : "A bbox entity which is not solid for the player only, but may serve as a pass-through trigger_look target
+
+Caution! It's still solid for monsters and the rest of the world, tho! For them, it keeps all its blocking characteristics (they can't see/pass through it)" []
 
 @PointClass base(Appearflags, Target, Targetname) size (16 16 16) color(192 0 192) = trigger_random_time : "Fire targets at random intervals
 

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -2620,6 +2620,12 @@ Check each field's description for more details.
 	message(string) : "Message"
 ]
 
+@baseclass = Homing
+[
+	homing(float) : "Aiming accuracy" : "0" : "How accurately the player must be facing the direction set by .angle to fire this trigger: from 0 (default) allowing to look up to 90° away from the ideal direction to 1 (looking straight in the intended direction).
+1 is too precise and constraining, it rarely occurs in game because of imprecisions. 0.6 or 0.7 is usually a good compromise."
+]
+
 @SolidClass base(OneTarget, OneTargetname, Appearflags, TriggerWait, FilterTouch) = trigger_changelevel : "Trigger: Change level"
 [
 	map(string) : "Next map"
@@ -2636,7 +2642,7 @@ Check each field's description for more details.
 	target(string) : "Specific intermission camera to use (works only if matching an info_intermission's targetname), otherwise a regular target to fire"
 ]
 
-@SolidClass base(Trigger, Actionable) = trigger_once : "Trigger: Activate once"
+@SolidClass base(Trigger, Actionable, Homing) = trigger_once : "Trigger: Activate once"
 [
 	health(integer) : "Health (shootable)"
 	is_waiting(choices) : "Trigger" : 0 =
@@ -2694,7 +2700,7 @@ NOTE: You must specify either the silver or gold key by setting the relevant spa
 	pain_target(string) : "Target to fire when not having key"
 ]
 
-@SolidClass base(Trigger, Actionable) = trigger_multiple : "Trigger: Activate multiple"
+@SolidClass base(Trigger, Actionable, Homing) = trigger_multiple : "Trigger: Activate multiple"
 [
 	wait(string) : "Wait before reset" : "0.2"
 	health(integer) : "Health (shootable)"
@@ -2713,7 +2719,7 @@ NOTE: You must specify either the silver or gold key by setting the relevant spa
 [
 	spawnflags(flags) = [ 1: "Not touchable" : 0 ]
 ]
-@SolidClass base(Trigger, OneTargetname, TriggerWait) = trigger_secret : "Trigger: Secret"
+@SolidClass base(Trigger, OneTargetname, TriggerWait, Homing) = trigger_secret : "Trigger: Secret"
 [
 	sounds(choices) : "Sound" : 1 =
 	[
@@ -2781,7 +2787,7 @@ don't forget to check the 'Slient' spawnflag so the player has no clue!
 @PointClass base(Trigger) color(0 192 192)= trigger_relay : "Trigger: Relay"
 [
 ]
-@SolidClass base(Appearflags, TriggerWait, FilterTouch) = trigger_take_weapon : "
+@SolidClass base(Appearflags, TriggerWait, FilterTouch, Homing) = trigger_take_weapon : "
 Trigger: Remove weapon (and/or ammo) on touch.
 
 Classic progs_dump 3.0 behavior:

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -89,6 +89,7 @@
 	a_ylw_mdl(string) : "Global Yellow Armor model" :  : "Use this field to replace all Yellow Armors with this model"
 	a_red_mdl(string) : "Global Red Armor model" :  : "Use this field to replace all Red Armors with this model"
 	mdl_head(string) : "Custom 'Puzzle items panel' sprite" :  : "Use this field to replace the default inventory plaque sprite"
+	mdl_body(string) : "Custom 'Inventory empty' sprite" :  : "Use this field to replace the default empty inventory caption sprite"
 	distance(integer) : "Distance between HUD items" : 70 : "Use this field to spread the HUD items, so that they can have wider captions"
 ]
 

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -3660,7 +3660,10 @@ sounds(integer) : "Track Number (ex 02->xx)" :  : "CD track or audio file to pla
 * has a clear line of sight to a targeted brush entity even if not looking at it
 otherwise, trigger the pain_target(s), if any.
 
-Use the first target key for the looked at item and subsequent targets to trigger events. Add a wait key to make this a trigger_multiple.
+Use the first target key for the looked at item and subsequent targets to trigger events.
+Caution! The first target is triggered as well, unless the 'Don't fire main target' spawnflag is checked.
+
+Add a wait key to make this a trigger_multiple.
 "
 [
 	speed(integer) : "Distance from player to search for trigger, adjust if the target is too far from the trigger" : 500
@@ -3677,6 +3680,7 @@ Use the first target key for the looked at item and subsequent targets to trigge
 	spawnflags(Flags) =
 	[
 		1 : "Line of sight" : 0 : "A clear line of sight exists, no matter the distance or the player's looking direction"
+		2 : "Don't fire main target" : 0 : "target looked at isn't triggered by player gaze"
 	]
 	pain_target(string) : "Target(s) to fire when the looking/los check fails"
 ]

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -2691,8 +2691,8 @@ NOTE: You must specify either the silver or gold key by setting the relevant spa
 	]
 	delay(float) : "Delay before trigger" : "0" : "Delay before trigger"
 	keyname(string) : "Sets the keyname of the item_key_custom which unlocks this entity. If any key spawnflag is selected (either silver or gold), this only changes the display name of the required key."
-	message(string) : "Custom message"
-	message2(string) : "Message when key used"
+	message(string) : "Message when key needed" : : "Set to '0' to print no message."
+	message2(string) : "Message when key used" : : "Set to '0' to print no message."
 	noise1(string) : "Sound file for the 'key required' sound (default is per worldtype)"
 	noise2(string) : "Sound file for the 'key used' sound (default is per worldtype)"
 	spawnflags(flags) =

--- a/hiptrig.qc
+++ b/hiptrig.qc
@@ -24,19 +24,15 @@ keytrigger_use function.  -- iw
 */
 void() keytrigger_unlock =
 {
-	// we can't just remove (self) here, because this is a touch function
-	// called while C code is looping through area links...
-	self.touch = SUB_Null;
-	self.use = SUB_Null;
-	self.nextthink = time + 0.1;
-	self.think = SUB_Remove;
-	self.message = "";
-
+	self.estate = STATE_INACTIVE;
 	SUB_UseTargets();
 };
 
 void() keytrigger_use =
 {
+	if (self.estate != STATE_ACTIVE)
+		return;
+		
 	if (self.attack_finished > time)
 		return;
 

--- a/items.qc
+++ b/items.qc
@@ -1519,15 +1519,18 @@ void() key_touch =
 	if (haskey && (other.cheater == 0))
 		return;
 	
-	if (other.flags & FL_CLIENT) {
-		sprint (other, "You got the ");
-		sprint (other, self.netname);
-		sprint (other,"\n");
-	}
+	if(!(self.spawnflags & /*Silent pickup*/ 2097152))
+	{
+		if (other.flags & FL_CLIENT) {
+			sprint (other, "You got the ");
+			sprint (other, self.netname);
+			sprint (other,"\n");
+		}
 
-	sound (other, CHAN_ITEM, self.noise, 1, ATTN_NORM);
-	if (other.flags & FL_CLIENT) {
-		stuffcmd (other, "bf\n");
+		sound (other, CHAN_ITEM, self.noise, 1, ATTN_NORM);
+		if (other.flags & FL_CLIENT) {
+			stuffcmd (other, "bf\n");
+		}
 	}
 
 // support for item_key_custom -- iw

--- a/items.qc
+++ b/items.qc
@@ -1468,6 +1468,7 @@ void(entity player, float show) toggle_inventory =
 	{
 		if(player) sound (player, CHAN_VOICE, "misc/puzzle.wav", 1, ATTN_NONE);
 		if(invPanel) setmodel (invPanel, invPanel.mdl);
+		if(invEmpty && player.skip_id1_overrides <= 0) setmodel (invEmpty, invEmpty.mdl); else setmodel (invEmpty, "");
 		if(invItem1) setmodel (invItem1, invItem1.mdl);
 		if(invItem2) setmodel (invItem2, invItem2.mdl);
 		if(invItem3) setmodel (invItem3, invItem3.mdl);
@@ -1483,6 +1484,7 @@ void(entity player, float show) toggle_inventory =
 	{
 		if(player) sound (player, CHAN_VOICE, "misc/puzzleaway.wav", 1, ATTN_NONE);
 		if(invPanel) setmodel (invPanel, "");
+		if(invEmpty) setmodel (invEmpty, "");
 		if(invItem1) setmodel (invItem1, "");
 		if(invItem2) setmodel (invItem2, "");
 		if(invItem3) setmodel (invItem3, "");
@@ -1599,6 +1601,13 @@ void() key_touch =
 		{
 			invPanel = spawn();
 			invPanel.mdl = self.obit_method;
+		}
+		
+		//Floating 'Inventory empty' panel
+		if(!invEmpty)
+		{
+			invEmpty = spawn();
+			invEmpty.mdl = self.obit_name;
 		}
 	}
 
@@ -1801,7 +1810,9 @@ void() item_key_custom =
 
 	//Floating 'Puzzle items' panel
 	if(world.mdl_head) self.obit_method = world.mdl_head; else self.obit_method = "gfx/puzzle.spr";
+	if(world.mdl_body) self.obit_name   = world.mdl_body; else self.obit_name   = "gfx/invempty.spr";
 	precache_model(self.obit_method);
+	precache_model(self.obit_name);
 	precache_sound("misc/puzzle.wav");
 	precache_sound("misc/puzzleaway.wav");
 	

--- a/items.qc
+++ b/items.qc
@@ -60,7 +60,7 @@ void(entity whatitem, float defaultdelay) CheckItemRespawn =
 
 		if (whatitem.respawndelay)	// custom respawn delay?
 			whatitem.nextthink = time + whatitem.respawndelay;
-		else
+		else if (defaultdelay > 0)
 			whatitem.nextthink = time + defaultdelay;
 	}
 	else if(whatitem.ritem == 2)
@@ -1616,6 +1616,10 @@ void() key_touch =
 		}
 	}
 
+	// SP respawning items support
+	self.think	= SUB_regen;
+	CheckItemRespawn(self, 0);
+	
 	if (!coop)
 	{
 		self.solid = SOLID_NOT;
@@ -1624,9 +1628,7 @@ void() key_touch =
 	}
 
 	activator = other;
-// fix key items firing their targets multiple times in coop -- iw
-//	SUB_UseTargets();				// fire all targets / killtargets
-	SUB_UseAndForgetTargets();
+	SUB_UseTargets();
 };
 
 

--- a/items.qc
+++ b/items.qc
@@ -2056,7 +2056,7 @@ void() item_artifact_invulnerability =
 	self.noise = "items/protect.wav";
 	// setmodel (self, "progs/invulner.mdl");
 	body_model ("progs/invulner.mdl");
-	self.netname = "Pentagram of Protection";
+	if (!self.netname) self.netname = "Pentagram of Protection";
 	self.items = IT_INVULNERABILITY;
 	resize('-16 -16 -24', '16 16 32');
 	if !(self.particles_offset)  // t_fog fix for custom models dumptruck_ds
@@ -2082,7 +2082,7 @@ void() item_artifact_envirosuit =
 	self.noise = "items/suit.wav";
 	// setmodel (self, "progs/suit.mdl");
 	body_model ("progs/suit.mdl");
-	self.netname = "Biosuit";
+	if (!self.netname) self.netname = "Biosuit";
 	self.items = IT_SUIT;
 	resize('-16 -16 -24', '16 16 32');
 	if !(self.particles_offset)  // t_fog fix for custom models dumptruck_ds
@@ -2110,7 +2110,7 @@ void() item_artifact_invisibility =
 	self.noise = "items/inv1.wav";
 	// setmodel (self, "progs/invisibl.mdl");
 	body_model ("progs/invisibl.mdl");
-	self.netname = "Ring of Shadows";
+	if (!self.netname) self.netname = "Ring of Shadows";
 	self.items = IT_INVISIBILITY;
 	resize('-16 -16 -24', '16 16 32');
 	if !(self.particles_offset)  // t_fog fix for custom models dumptruck_ds
@@ -2137,8 +2137,7 @@ void() item_artifact_super_damage =
 	self.noise = "items/damage.wav";
 	// setmodel (self, "progs/quaddama.mdl");
 	body_model ("progs/quaddama.mdl");
-	if !(self.netname) // custom name -- dumptruck_ds
-	self.netname = "Quad Damage";
+	if (!self.netname) self.netname = "Quad Damage";
 	self.items = IT_QUAD;
 	resize('-16 -16 -24', '16 16 32');
 	if !(self.particles_offset)  // t_fog fix for custom models dumptruck_ds

--- a/items.qc
+++ b/items.qc
@@ -1572,6 +1572,8 @@ void() key_touch =
 			if(label) setmodel(label, label.mdl);
 		}
 		
+		if(invEmpty) setmodel (invEmpty, "");
+		
 		//Assign it to the first available slot
 		if(!invItem1)
 		{

--- a/keydata.qc
+++ b/keydata.qc
@@ -287,6 +287,6 @@ void(entity client, float item_flags, float customkey_flags) RemoveKeys =
 		//Do player still have something in their custom keys inventory?
 		if (invItem1 == world && invItem2 == world && invItem3 == world && invItem4 == world && invItem5 == world) client.skip_id1_overrides = 0;
 		
-		if(invEmpty && client.skip_id1_overrides <= 0) setmodel (invEmpty, invEmpty.mdl); else setmodel (invEmpty, "");
+		if(invEmpty && client.skip_id1_overrides <= 0 && invPanel.model == invPanel.mdl) setmodel (invEmpty, invEmpty.mdl); else setmodel (invEmpty, "");
 	}
 };

--- a/keydata.qc
+++ b/keydata.qc
@@ -223,7 +223,7 @@ void(entity client, float item_flags, float customkey_flags) RemoveKeys =
 			(client.customkeys & customkey_flags);
 			
 // Custom keys inventory
-	if(customkey_flags)
+	if(customkey_flags && client.classname == "player")
 	{
 		//Reassign the slots
 		if(invItem1.customkeys & customkey_flags)
@@ -282,9 +282,11 @@ void(entity client, float item_flags, float customkey_flags) RemoveKeys =
 			invLabel5 = world;
 		}
 		
-		other.skip_id1_overrides -= 1;
+		client.skip_id1_overrides -= 1;
 
 		//Do player still have something in their custom keys inventory?
-		if (invItem1 == world && invItem2 == world && invItem3 == world && invItem4 == world && invItem5 == world) other.skip_id1_overrides = 0;
+		if (invItem1 == world && invItem2 == world && invItem3 == world && invItem4 == world && invItem5 == world) client.skip_id1_overrides = 0;
+		
+		if(invEmpty && client.skip_id1_overrides <= 0) setmodel (invEmpty, invEmpty.mdl); else setmodel (invEmpty, "");
 	}
 };

--- a/keylock.qc
+++ b/keylock.qc
@@ -195,10 +195,13 @@ void(entity client, string failure_message, string success_message,
 	{
 		if (client.flags & FL_CLIENT)
 		{
-			if (failure_message != "")
-				centerprint (client, failure_message);
-			else
-				centerprint2 (client, "You need the ", self.netname);
+			if (failure_message != "0")
+			{
+				if (failure_message != "")
+					centerprint (client, failure_message);
+				else
+					centerprint2 (client, "You need the ", self.netname);
+			}
 			sound (self, CHAN_VOICE, self.noise3, 1, ATTN_NORM);
 		}
 		failure_func();
@@ -218,17 +221,20 @@ void(entity client, string failure_message, string success_message,
 
 	if (client.flags & FL_CLIENT)
 	{
-		if (success_message != "")
-		{
-			sprint (client, success_message);
-			sprint (client, "\n");
-		}
-		else
-		{
-			sprint (client, s);
-			sprint (client, self.netname);
-			sprint (client, "\n");
-		}
+			if (success_message != "0")
+			{
+				if (success_message != "")
+				{
+					sprint (client, success_message);
+					sprint (client, "\n");
+				}
+				else
+				{
+					sprint (client, s);
+					sprint (client, self.netname);
+					sprint (client, "\n");
+				}
+			}
 	}
 	sound (self, CHAN_ITEM, self.noise4, 1, ATTN_NORM);
 	

--- a/misc.qc
+++ b/misc.qc
@@ -1124,9 +1124,15 @@ A bbox entity which is solid for the player only
 */
 void() func_playerclip =
 {
-	self.targetname=self.targetname2=self.targetname3=self.targetname4=string_null;
-	self.spawnflags = /*Keep visible*/4;
-	func_togglevisiblewall();
+	func_wall();
+};
+
+/*QUAKED func_playernoclip
+A bbox entity which is solid for the player only
+*/
+void() func_playernoclip =
+{
+	func_wall();
 };
 
 /*****************

--- a/triggers.qc
+++ b/triggers.qc
@@ -1534,7 +1534,16 @@ void() onlookat_think =
 			self.nextthink = time + self.wait;
 		}
 	}
+	self.use = look_use;
 	self.touch = onlookat_touch;
+};
+
+void() look_use =
+{
+	//Trigger implementation now relying on .think rather than .touch like in progs_dump. This doesn't changes anything for regular target entities
+	//but now it allows for a func_playernoclip to be targeted as well, thanks to a small physics hack in client.hc.
+	self.think = onlookat_think;
+	self.nextthink = time + 0.1;
 };
 
 void() onlookat_touch =
@@ -1545,10 +1554,7 @@ void() onlookat_touch =
 	//Inhibit any further touch until this one has been fully proceeded by onlookat_think (restored at the end of it)
 	self.touch = SUB_Null;
 	
-	//Trigger implementation now relying on .think rather than .touch. This doesn't changes anything for regular target entities
-	//but now it allows for a func_playernoclip to be targeted as well, thanks to a small physics hack in client.hc.
-	self.think = onlookat_think;
-	self.nextthink = time + 0.1;
+	look_use();
 };
 
 /*QUAKED trigger_look (.5 .5 .5) ? X X X X X X X X NOT_ON_EASY NOT_ON_NORMAL NOT_ON_HARD_OR_NIGHTMARE NOT_IN_DEATHMATCH NOT_IN_COOP NOT_IN_SINGLEPLAYER X NOT_ON_HARD_ONLY NOT_ON_NIGHTMARE_ONLY
@@ -1605,6 +1611,7 @@ void() trigger_look =
 		self.speed = 500;
 
     InitTrigger();
+	self.use = look_use;
     self.touch = onlookat_touch;
 
     SUB_CheckWaiting();
@@ -1900,6 +1907,8 @@ float FILTER_OP_GTE = 4;
 float FILTER_OP_BITMASK_AND = 5;
 float FILTER_OP_BITMASK_OR = 6;
 float FILTER_OP_MODULO = 7;
+float FILTER_OP_NOT_EQUAL = 8;
+float FILTER_OP_BITMASK_NAND = 9;
 
 void() trigger_filter_use = {
 	self.state = 0;

--- a/triggers.qc
+++ b/triggers.qc
@@ -1452,12 +1452,24 @@ void() onlookat_touch =
         }
         else
         {    // we can't just remove (self) here, because this is a touch function
-            // called wheil C code is looping through area links...
+            // called while C code is looping through area links...
             self.touch = SUB_Null;
             self.nextthink = time + 0.1;
             self.think = SUB_Remove;
         }
     }
+	else if (self.pain_target != "")
+	{
+		self.use = multi_trigger;
+		
+		SUB_UsePain2();
+
+		if (self.wait > 0)
+		{
+			self.think = multi_wait;
+			self.nextthink = time + self.wait;
+		}
+	}
 };
 /*QUAKED trigger_look (.5 .5 .5) ? X X X X X X X X NOT_ON_EASY NOT_ON_NORMAL NOT_ON_HARD_OR_NIGHTMARE NOT_IN_DEATHMATCH NOT_IN_COOP NOT_IN_SINGLEPLAYER X NOT_ON_HARD_ONLY NOT_ON_NIGHTMARE_ONLY
 This will trigger when a player is within the brush trigger and looks directly at a target entity.
@@ -1627,16 +1639,23 @@ float SETSTATE_CLOSEALLDOORS = 2;
 float SETSTATE_DONTRESETBUTTON = 4;
 
 float(entity e) entity_get_state = {
-	if(e.classname == "func_door") return e.owner.estate;
-	else return e.estate;
+	if(e.classname == "func_door")
+		return e.owner.estate;
+	else if(e.classname == "func_togglevisiblewall")
+		return 1 - e.estate;
+	else
+		return e.estate;
 };
 
 void(entity e, float state, float flags) entity_set_state = {
+	local entity tempself;
 	float closealldoors;
 
 	if(e.classname == "trigger_teleport") {
 		if (state == STATE_ACTIVE)
 			sound (e, CHAN_WEAPON, "ambience/hum1.wav", 0.5, ATTN_NORM);
+		else
+			sound (e, CHAN_WEAPON, "misc/null.wav", 0.5, ATTN_NORM);
 		e.estate = state;
 	}
 	else if(e.classname == "func_button") {
@@ -1648,6 +1667,38 @@ void(entity e, float state, float flags) entity_set_state = {
 
 		if (state == STATE_ACTIVE) door_estate_unlock(e, closealldoors);
 		else door_estate_lock(e, closealldoors);
+	}
+	else if(e.classname == "func_togglevisiblewall") {
+		tempself = self;
+		self = e;
+		e.estate = state;
+		func_togglevisiblewall_use();
+		self = tempself;
+	}
+	else if(e.classname == "light") {
+		tempself = self;
+		self = e;
+		if (state == STATE_ACTIVE) {
+			dprint("turning on light ");
+			dprint(self.targetname2);
+			dprint("\n");
+			self.spawnflags = self.spawnflags - START_OFF;
+			if (self.spawnflags & FADE_IN_OUT && !self.style2)
+				light_fade_in();
+			else
+				lightstyle(self.style, lightstyle_lookup(self.style2));
+		}
+		else {
+			dprint("turning off light ");
+			dprint(self.targetname2);
+			dprint("\n");
+			self.spawnflags = self.spawnflags + START_OFF;
+			if (self.spawnflags & FADE_IN_OUT && !self.style2)
+				light_fade_out();
+			else
+				lightstyle(self.style, "a");
+		}
+		self = tempself;
 	}
 	else e.estate = state;
 

--- a/triggers.qc
+++ b/triggers.qc
@@ -1643,6 +1643,12 @@ float(entity e) entity_get_state = {
 		return e.owner.estate;
 	else if(e.classname == "func_togglevisiblewall")
 		return 1 - e.estate;
+	else if(e.classname == "ltrail_start")
+		return !(e.spawnflags & LT_ACTIVE);
+	else if(e.classname == "light")
+		return e.spawnflags & START_OFF;
+	else if(e.classname == "togglewall")
+		return 1 - e.state;
 	else
 		return e.estate;
 };
@@ -1675,29 +1681,22 @@ void(entity e, float state, float flags) entity_set_state = {
 		func_togglevisiblewall_use();
 		self = tempself;
 	}
-	else if(e.classname == "light") {
+	else if(e.classname == "togglewall" && state != entity_get_state(e)) {
 		tempself = self;
 		self = e;
-		if (state == STATE_ACTIVE) {
-			dprint("turning on light ");
-			dprint(self.targetname2);
-			dprint("\n");
-			self.spawnflags = self.spawnflags - START_OFF;
-			if (self.spawnflags & FADE_IN_OUT && !self.style2)
-				light_fade_in();
-			else
-				lightstyle(self.style, lightstyle_lookup(self.style2));
-		}
-		else {
-			dprint("turning off light ");
-			dprint(self.targetname2);
-			dprint("\n");
-			self.spawnflags = self.spawnflags + START_OFF;
-			if (self.spawnflags & FADE_IN_OUT && !self.style2)
-				light_fade_out();
-			else
-				lightstyle(self.style, "a");
-		}
+		blocker_use();
+		self = tempself;
+	}
+	else if(e.classname == "ltrail_start" && e.spawnflags & LT_TOGGLE && state != entity_get_state(e)) {
+		tempself = self;
+		self = e;
+		ltrail_start_fire();
+		self = tempself;
+	}
+	else if(e.classname == "light" && e.targetname && state != entity_get_state(e)) {
+		tempself = self;
+		self = e;
+		light_use();
 		self = tempself;
 	}
 	else e.estate = state;
@@ -1717,8 +1716,10 @@ void(string matchstring, .string matchfield, float state, float flags) target_se
 	t = find (world, matchfield, matchstring);
 	while (t != world) {
 		if(state == -1){
-			if(entity_get_state(t) == STATE_ACTIVE) entity_set_state(t, STATE_INACTIVE, flags);
-			else entity_set_state(t, STATE_ACTIVE, flags);
+			if(entity_get_state(t) == STATE_ACTIVE)
+				entity_set_state(t, STATE_INACTIVE, flags);
+			else
+				entity_set_state(t, STATE_ACTIVE, flags);
 		}
 		else entity_set_state(t, state, flags);
 

--- a/triggers.qc
+++ b/triggers.qc
@@ -1487,7 +1487,7 @@ void() onlookat_touch =
 			self.speed = 500;
 		traceline(player_offset, (player_offset + (v_forward * self.speed)), FALSE, other);
 		
-		success = (trace_ent.targetname == self.target);
+		success = (trace_ent.targetname == self.target || trace_ent.targetname2 == self.target || trace_ent.targetname3 == self.target || trace_ent.targetname4 == self.target);
 	}
 
     if (success)
@@ -1498,12 +1498,21 @@ void() onlookat_touch =
             centerprint (other, self.message);
         }
         self.use = multi_trigger;
-        SUB_UseTargets();
+        
+		if (self.spawnflags & /*Don't fire main target*/ 2)
+		{
+			string otarget = self.target;
+			self.target = "D0n't f1r3 m41n t4rg3t!";
+			SUB_UseTargets();
+			self.target = otarget;
+		}
+		else
+			SUB_UseTargets();
 
-				if (self.noise != "")
-				sound (self, CHAN_VOICE, self.noise, 1, ATTN_NORM);
-				else
-				sound (self, CHAN_VOICE, self.noise1, 1, ATTN_NORM);
+		if (self.noise != "")
+		sound (self, CHAN_VOICE, self.noise, 1, ATTN_NORM);
+		else
+		sound (self, CHAN_VOICE, self.noise1, 1, ATTN_NORM);
 
         // added wait
         if (self.wait > 0)

--- a/triggers.qc
+++ b/triggers.qc
@@ -849,6 +849,8 @@ MONSTER_ONLY(16) will only teleport monsters
 		objerror ("no target");
 	self.use = teleport_use;
 
+	precache_sound ("misc/null.wav");
+	
 	if (!(self.spawnflags & SILENT))
 	{
 		precache_sound ("ambience/hum1.wav");

--- a/triggers.qc
+++ b/triggers.qc
@@ -1412,26 +1412,85 @@ void() trigger_cdtrack =
 ///////////////////////////////////////////////////////////////
 void() onlookat_touch =
 {
+	float success = FALSE;
+	
 	// from Copper -- dumptruck_ds
 	if (!CheckValidTouch()) return;
 
-  if (self.nextthink > time)
-  {
-        return;        // allready been triggered
-  }
+	if (self.nextthink > time)
+	{
+		return;        // allready been triggered
+	}
 
     //added player view offset to make this more accurate to the player crosshairs
     local vector player_offset;
     player_offset = other.origin + other.view_ofs;
 
-    makevectors(other.v_angle);
+	if (self.spawnflags & /*Line of sight*/1)
+	{
+		//'Line of sight' mode: check whether there is a clear line of sight between the player and its target, no matter where the player is looking
+		
+        // Find all entities matching self.target
+		// The test is successful as soon as one of them has a clear los to the player.
+		
+		for (entity e = world; (e = find(e, targetname, self.target)); )
+		{
+			traceline(player_offset, (e.mins + e.maxs) * 0.5, 1, other);
+			if (trace_ent == e)
+			{
+				success = TRUE;
+				break;
+			}
+		}
+		
+		if(!success)
+		for (entity e = world; (e = find(e, targetname2, self.target)); )
+		{
+			traceline(player_offset, (e.mins + e.maxs) * 0.5, 1, other);
+			if (trace_ent == e)
+			{
+				success = TRUE;
+				break;
+			}
+		}
+		
+		if(!success)
+		for (entity e = world; (e = find(e, targetname3, self.target)); )
+		{
+			traceline(player_offset, (e.mins + e.maxs) * 0.5, 1, other);
+			if (trace_ent == e)
+			{
+				success = TRUE;
+				break;
+			}
+		}
+		
+		if(!success)
+		for (entity e = world; (e = find(e, targetname4, self.target)); )
+		{
+			traceline(player_offset, (e.mins + e.maxs) * 0.5, 1, other);
+			if (trace_ent == e)
+			{
+				success = TRUE;
+				break;
+			}
+		}
+	}
+	else
+	{
+		//Standard mode: check whether the player is directly looking at its target (target under their crosshair)
+	
+		makevectors(other.v_angle);
 
-    //using speed to determine the reach of the trace
-    if(!self.speed)
-        self.speed = 500;
-    traceline(player_offset, (player_offset + (v_forward * self.speed)), FALSE, other);
+		//using speed to determine the reach of the trace
+		if(!self.speed)
+			self.speed = 500;
+		traceline(player_offset, (player_offset + (v_forward * self.speed)), FALSE, other);
+		
+		success = (trace_ent.targetname == self.target);
+	}
 
-    if ((trace_ent.targetname == self.target))
+    if (success)
     {
         // Play message if available
         if (self.message != "")
@@ -1522,6 +1581,9 @@ void() trigger_look =
         precache_sound (self.noise1);
 				self.noise = self.noise1;
     }
+
+	if(!self.speed)
+		self.speed = 500;
 
     InitTrigger();
     self.touch = onlookat_touch;

--- a/triggers.qc
+++ b/triggers.qc
@@ -2074,26 +2074,31 @@ void() trigger_filter_use = {
 	}
 
 	if (fieldtype == FILTER_FIELDTYPE_FLOAT) {
-		if 		(op == FILTER_OP_EQUALS) 		{if (targfloat == self.count) result = 1;}
-		else if (op == FILTER_OP_LT) 			{if (targfloat <  self.count) result = 1;}
-		else if (op == FILTER_OP_LTE) 			{if (targfloat <= self.count) result = 1;}
-		else if (op == FILTER_OP_GT) 			{if (targfloat >  self.count) result = 1;}
-		else if (op == FILTER_OP_GTE) 			{if (targfloat >= self.count) result = 1;}
-		else if (op == FILTER_OP_BITMASK_AND)	{if (targfloat &  self.count) result = 1;}
-		else if (op == FILTER_OP_BITMASK_OR)	{if (targfloat |  self.count) result = 1;}
-		else if (op == FILTER_OP_MODULO)		{if (self.count == mod(targfloat,self.cnt)) result = 1;}
-		else 									{if (targfloat == self.count) result = 1;}
+		if 		(op == FILTER_OP_EQUALS) 		{if   (targfloat == self.count)  result = 1;}
+		else if (op == FILTER_OP_LT) 			{if   (targfloat <  self.count)  result = 1;}
+		else if (op == FILTER_OP_LTE) 			{if   (targfloat <= self.count)  result = 1;}
+		else if (op == FILTER_OP_GT) 			{if   (targfloat >  self.count)  result = 1;}
+		else if (op == FILTER_OP_GTE) 			{if   (targfloat >= self.count)  result = 1;}
+		else if (op == FILTER_OP_BITMASK_AND)	{if   (targfloat &  self.count)  result = 1;}
+		else if (op == FILTER_OP_BITMASK_OR)	{if   (targfloat |  self.count)  result = 1;}
+		else if (op == FILTER_OP_MODULO)		{if   (self.count == mod(targfloat,self.cnt)) result = 1;}
+		else if (op == FILTER_OP_NOT_EQUAL) 	{if   (targfloat != self.count)  result = 1;}
+		else if (op == FILTER_OP_BITMASK_NAND)	{if (!(targfloat &  self.count)) result = 1;}
+		else 									{if   (targfloat == self.count)  result = 1;}
 	}
 	else if (fieldtype == FILTER_FIELDTYPE_FLAG) {
-		if 		(op == FILTER_OP_EQUALS) 		{if (targfloat == self.aflag) result = 1;}
-		else if (op == FILTER_OP_BITMASK_AND)	{if (targfloat &  self.aflag) result = 1;}
-		else if (op == FILTER_OP_BITMASK_OR)	{if (targfloat |  self.aflag) result = 1;}
-		else if (op == FILTER_OP_MODULO)		{if (self.count == mod(targfloat,self.cnt)) result = 1;}
-		else 									{if (targfloat == self.aflag) result = 1;}
+		if 		(op == FILTER_OP_EQUALS) 		{if   (targfloat == self.aflag)  result = 1;}
+		else if (op == FILTER_OP_BITMASK_AND)	{if   (targfloat &  self.aflag)  result = 1;}
+		else if (op == FILTER_OP_BITMASK_OR)	{if   (targfloat |  self.aflag)  result = 1;}
+		else if (op == FILTER_OP_MODULO)		{if   (self.count == mod(targfloat,self.cnt)) result = 1;}
+		else if (op == FILTER_OP_NOT_EQUAL) 	{if   (targfloat != self.aflag)  result = 1;}
+		else if (op == FILTER_OP_BITMASK_NAND)	{if (!(targfloat &  self.aflag)) result = 1;}
+		else 									{if   (targfloat == self.aflag)  result = 1;}
 	}
 	else if (fieldtype == FILTER_FIELDTYPE_STRING) {
-
-		if (targstring == self.type) result = 1;
+		if 		(op == FILTER_OP_EQUALS) 		{if   (targstring == self.type)  result = 1;}
+		else if (op == FILTER_OP_NOT_EQUAL) 	{if   (targstring != self.type)  result = 1;}
+		else 									{if   (targstring == self.type)  result = 1;}
 	}
 	else {
 		objerror ("invalid fieldtype");

--- a/triggers.qc
+++ b/triggers.qc
@@ -1410,18 +1410,12 @@ void() trigger_cdtrack =
 ///////////////////////////////////////////////////////////////
 //trigger_look (a.k.a. trigger_onlookat from NullPointPaladin!)
 ///////////////////////////////////////////////////////////////
-void() onlookat_touch =
+void() onlookat_think =
 {
 	float success = FALSE;
+
+	other = find(world, classname, "player");
 	
-	// from Copper -- dumptruck_ds
-	if (!CheckValidTouch()) return;
-
-	if (self.nextthink > time)
-	{
-		return;        // allready been triggered
-	}
-
     //added player view offset to make this more accurate to the player crosshairs
     local vector player_offset;
     player_offset = other.origin + other.view_ofs;
@@ -1540,7 +1534,23 @@ void() onlookat_touch =
 			self.nextthink = time + self.wait;
 		}
 	}
+	self.touch = onlookat_touch;
 };
+
+void() onlookat_touch =
+{
+	// from Copper -- dumptruck_ds
+	if (!CheckValidTouch()) return;
+
+	//Inhibit any further touch until this one has been fully proceeded by onlookat_think (restored at the end of it)
+	self.touch = SUB_Null;
+	
+	//Trigger implementation now relying on .think rather than .touch. This doesn't changes anything for regular target entities
+	//but now it allows for a func_playernoclip to be targeted as well, thanks to a small physics hack in client.hc.
+	self.think = onlookat_think;
+	self.nextthink = time + 0.1;
+};
+
 /*QUAKED trigger_look (.5 .5 .5) ? X X X X X X X X NOT_ON_EASY NOT_ON_NORMAL NOT_ON_HARD_OR_NIGHTMARE NOT_IN_DEATHMATCH NOT_IN_COOP NOT_IN_SINGLEPLAYER X NOT_ON_HARD_ONLY NOT_ON_NIGHTMARE_ONLY
 This will trigger when a player is within the brush trigger and looks directly at a target entity.
 Use the first target key for the "looked at entity" and use the subsequent targets (2-4) to trigger other events.

--- a/triggers.qc
+++ b/triggers.qc
@@ -112,7 +112,7 @@ void() multi_touch = //dumptruck_ds
 	if (self.movedir != '0 0 0')
 	{
 		makevectors (other.angles);
-		if (v_forward * self.movedir < 0)
+		if (!(v_forward * self.movedir >= self.homing)) //self.homing is the minimum accuracy; default is 0 (up to 90° away from the ideal direction); up to 1 (exactly the ideal direction, no compromise!)
 			return;		// not facing the right way
 	}
 

--- a/triggers.qc
+++ b/triggers.qc
@@ -301,13 +301,11 @@ void() counter_use =
 	if (other.aflag > 0 && other.aflag != self.cnt) 
 	  self.items = 1; //Wrong order
 	
-	/**/
+	//Re:Mobilize is for many reasons singleplayer-focused, so we won't bother with a loop to find "all the players", or about the player being he activator.
+	//As long as the counter is not flagged as 'No Message', a message is printed. Period.
 	entity msgEnt = world;
-	if (activator.classname == "player" && (self.spawnflags & SPAWNFLAG_NOMESSAGE) == 0)
-		msgEnt = activator;
-	else if (self.spawnflags & TRIGGER_CENTERPRINTALL)
-		msgEnt = find(world, classname, "player"); //Re:Mobilize is for many reasons singleplayer-focused, so let's not bother with a loop to find "all the players". Here the spawnflags simply means "send a message to player never mind they're the direct activator or not".
-	/**/
+	if (self.spawnflags & SPAWNFLAG_NOMESSAGE == 0)
+		msgEnt = find(world, classname, "player");
 	
 	if (self.count != 0)
 	{


### PR DESCRIPTION
To avoid messy situation where you lost track of how many times the thing was toggled and whether it's currently ON or OFF (and to avoid super complex setups involving tons of side entities to figure out), this PR allows to force the state to either ON or OFF by means of target_setstate (which already does the same for other entitires).

Also incorporated latest edits made in progs_dump to the target_setstate code to support lights.

Also added pain_target support to trigger_look in the same spirit as it's used in other entities: targets fired when the trigger's base condition is NOT met (i.e. when the player is NOT looking at the trigger's target).