### PR TITLE
Look at the air

### DIFF
--- a/client.qc
+++ b/client.qc
@@ -1244,11 +1244,16 @@ else
 	}
 		
 	for (entity e = world; (e = find(e, face_always, "1")); )
-		e.angles = vectoangles(self.origin - e.origin);
+		e.angles = vectoangles(self.origin + self.view_ofs - e.origin);
 	for (entity e = world; (e = find(e, face_always, "2")); )
 	{
 		e.angles = vectoangles(self.origin - e.origin);
 		e.angles_x = 0;
+	}
+	for (entity e = world; (e = find(e, face_always, "3")); )
+	{
+		e.angles = vectoangles(self.origin + self.view_ofs - e.origin);
+		e.angles_x = -e.angles_x;
 	}
 };
 

--- a/cutscene.qc
+++ b/cutscene.qc
@@ -770,7 +770,7 @@ local   entity  scrpt;
     self.script_delay = scrpt.script_delay;
     self.script_time = time + 1;
     self.script_count = self.script_count + 1;
-    centerprint (self, scrpt.message);
+    if (scrpt.message) centerprint (self, scrpt.message);
 
     if (self.script_count == self.script_delay)
     {

--- a/doors.qc
+++ b/doors.qc
@@ -1038,7 +1038,7 @@ void () func_door_secret =
 	if(self.noise3 == "") self.noise3 = default_noise3; //secret door stop noise
 	precache_sound (self.noise1);
 	precache_sound (self.noise2);
-	precache_sound (self.noise3);
+	if(self.noise3 != "0") precache_sound (self.noise3);
 
 	if (!self.dmg)
 		self.dmg = 2;

--- a/doors.qc
+++ b/doors.qc
@@ -47,11 +47,30 @@ void() door_blocked =
 	}
 };
 
-
 void() door_hit_top =
 {
 	sound (self, CHAN_VOICE, self.noise1, 1, ATTN_NORM);
 	self.state = STATE_TOP;
+	
+	if (self.spawnflags & /*Staged targets*/ 128)
+	{
+		if (self.target2!="")
+		{
+			string otarget = self.target;
+			string otarget3 = self.target3;
+			string otarget4 = self.target4;
+			string okilltarget = self.killtarget;
+			string okilltarget2 = self.killtarget2;
+			self.target = self.target3 = self.target4 = self.killtarget = self.killtarget2 = "";
+			SUB_UseTargets();
+			self.target = otarget;
+			self.target3 = otarget3;
+			self.target4 = otarget4;
+			self.killtarget = okilltarget;
+			self.killtarget2 = okilltarget2;
+		}
+	}
+	
 	if (self.spawnflags & DOOR_TOGGLE)
 		return;		// don't come down automatically
 	self.think = door_go_down;
@@ -62,6 +81,25 @@ void() door_hit_bottom =
 {
 	sound (self, CHAN_VOICE, self.noise1, 1, ATTN_NORM);
 	self.state = STATE_BOTTOM;
+	
+	if (self.spawnflags & /*Staged targets*/ 128)
+	{
+		if (self.target4!="")
+		{
+			string otarget = self.target;
+			string otarget2 = self.target2;
+			string otarget3 = self.target3;
+			string okilltarget = self.killtarget;
+			string okilltarget2 = self.killtarget2;
+			self.target = self.target2 = self.target3 = self.killtarget = self.killtarget2 = "";
+			SUB_UseTargets();
+			self.target = otarget;
+			self.target2 = otarget2;
+			self.target3 = otarget3;
+			self.killtarget = okilltarget;
+			self.killtarget2 = okilltarget2;
+		}
+	}
 };
 
 void() door_go_down =
@@ -79,6 +117,25 @@ void() door_go_down =
 	self.state = STATE_DOWN;
 	SUB_CalcMove (self.pos1, self.speed, door_hit_bottom);
 	
+	if (self.spawnflags & /*Staged targets*/ 128)
+	{
+		if (self.target3!="")
+		{
+			string otarget = self.target;
+			string otarget2 = self.target2;
+			string otarget4 = self.target4;
+			string okilltarget = self.killtarget;
+			string okilltarget2 = self.killtarget2;
+			self.target = self.target2 = self.target4 = self.killtarget = self.killtarget2 = "";
+			SUB_UseTargets();
+			self.target = otarget;
+			self.target2 = otarget2;
+			self.target4 = otarget4;
+			self.killtarget = okilltarget;
+			self.killtarget2 = okilltarget2;
+		}
+	}
+
 	if(self.switchshadstyle) {
 		shadow = self.shadowcontroller;
 		oldself = self;
@@ -115,7 +172,26 @@ void() door_go_up =
 	self.state = STATE_UP;
 	SUB_CalcMove (self.pos2, self.speed, door_hit_top);
 
-	SUB_UseTargets();
+	if (self.spawnflags & /*Staged targets*/ 128)
+	{
+		if (self.target!="")
+		{
+			string otarget2 = self.target2;
+			string otarget3 = self.target3;
+			string otarget4 = self.target4;
+			string okilltarget = self.killtarget;
+			string okilltarget2 = self.killtarget2;
+			self.target2 = self.target3 = self.target4 = self.killtarget = self.killtarget2 = "";
+			SUB_UseTargets();
+			self.target2 = otarget2;
+			self.target3 = otarget3;
+			self.target4 = otarget4;
+			self.killtarget = okilltarget;
+			self.killtarget2 = okilltarget2;
+		}
+	}
+	else
+		SUB_UseTargets();
 	
 	if(self.switchshadstyle) {
 		shadow = self.shadowcontroller;

--- a/dtmisc.qc
+++ b/dtmisc.qc
@@ -8,7 +8,7 @@
 
 void() play_sound_use =
    {
-   if (self.spawnflags & 1)
+   if (self.spawnflags & /*Toggle*/ 1)
       {
       if (self.state == 0)
          {
@@ -70,7 +70,7 @@ void() play_sound_triggered =
    if (self.speed == -1)
       // self.speed = 0;
       self.speed = ATTN_NONE;
-   if (self.spawnflags & 1)
+   if (self.spawnflags & /*Toggle*/ 1)
       if (self.impulse == 0)
          self.impulse = 7;
    self.use = play_sound_use;

--- a/dtmisc.qc
+++ b/dtmisc.qc
@@ -226,33 +226,39 @@ When triggered, creates a Spawn death explosion at it's origin. Causes damage.
 
 */
 
-void () play_tbaby_fx = //thanks Khreathor -- dumptruck_ds
+void () play_tbaby_fx =
+{
+	if(!(self.spawnflags & /*No damage*/ 1))
+		T_RadiusDamage (self, self, 120, world);
 
-{
-  tbaby_die2();
-}
-void() play_tbabyexplode =
-{
-  if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
-    return;
-  precache_sound2 ("blob/death1.wav");
-  self.use = play_tbaby_fx;
+	if(!(self.spawnflags & /*Silent*/ 2))
+		sound_death (self, CHAN_VOICE, self.noise, 1, ATTN_NORM);
+	
+	WriteByte (MSG_BROADCAST, SVC_TEMPENTITY);
+	WriteByte (MSG_BROADCAST, TE_TAREXPLOSION);
+	WriteCoord (MSG_BROADCAST, self.origin_x);
+	WriteCoord (MSG_BROADCAST, self.origin_y);
+	WriteCoord (MSG_BROADCAST, self.origin_z);
+
+	if(!(self.spawnflags & /*No explosion*/ 4))
+		BecomeExplosion ();
+
+	DropStuff();
 };
 
+void() play_tbabyexplode = { play_spawnexpl(); }; //Kept for compatibility but not even documented; probably a former name for the same thing.
 
 /*QUAKED play_spawnexpl (0.3 0.1 0.6) (-10 -10 -8) (10 10 8)
-
-When triggered, creates a Spawn death explosion at it's origin. Causes damage.
-
+When triggered, creates a Spawn death explosion at it's origin. Causes damage by default.
 */
-
 void() play_spawnexpl =
 {
-  if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
-    return;
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
 
-  precache_sound2 ("blob/death1.wav");
-  self.use = play_tbaby_fx;
+	if(!self.noise) self.noise = "blob/death1.wav";
+	precache_sound2 (self.noise);
+	self.use = play_tbaby_fx;
 };
 
 /*QUAKED play_lavasplash (0.3 0.1 0.6) (-10 -10 -8) (10 10 8)

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -2875,7 +2875,11 @@ Don't forget that buttons targeting a counter should always be wait|-1 anyway, n
 ]
 @SolidClass base(Angle, Appearflags, Targetname, TriggerWait) = trigger_push : "Trigger: Push"
 [
-	spawnflags(flags) = [ 1: "Push once" : 0 ]
+	spawnflags(flags) =
+	[
+		1: "Push once" : 0
+		16: "Silent" : 0
+	]
 	speed(integer) : "Speed" : 1000
 ]
 @SolidClass base(Angle, Appearflags, Targetname, TriggerWait) = trigger_push_custom : "Trigger: Push (Custom): Can be toggled on and off, use a custom sound (noise) and be made silent.

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -2794,6 +2794,7 @@ don't forget to check the 'Slient' spawnflag so the player has no clue!
 		0 : "Default"
 		1 : "Wait for Trigger"
 	]
+	include(target_destination) : "Entity's targetname to teleport at destination, no matter its initial location (only 1 matching entity at a time, must have health >= 0)"
 ]
 
 @SolidClass base(Appearflags, TriggerWait, FilterTouch) = trigger_setskill : "Trigger: Set skill"

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -930,6 +930,7 @@ style(Choices) : "Attack type" =
 	[
 		0 : "Default"
 		1	: "Lavaballs"
+		2	: "Melee only"
 	]
 ]
 @PointClass base(Monster, CustomMdls) size(-128 -128 -24, 128 128 256) model(

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -3099,6 +3099,13 @@ keep_ammo(integer): "If 1, explosion entity remains even after finishing animati
 
 @PointClass base(Targetname, Appearflags) size(16 16 24) color(150 0 150) = play_spawnexpl : "When triggered, plays the Spawn death explosion. Causes damage."
 [
+	noise(string) : "Custom sound file to play (otherwise default spawn explosion sound)"
+	spawnflags(flags) =
+	[
+		1 : "No damage" : 0
+		2 : "Silent" : 0
+		4 : "No explosion" : 0
+	]
 ]
 
 @PointClass base(Targetname, Appearflags) size(16 16 24) color(255 128 0) = play_mflash : "When triggered, plays a brief muzzle flash effect.

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -344,6 +344,7 @@ NOTE when a trigger_teleport has a targetname it must be triggered to operate, s
 [
 	mangle(string) : "Camera angle (Pitch Yaw Roll)"
 	targetname(string) : "Use to force this intermission camera by making it the target of a trigger_changelevel"
+	target(string) : "Entity to aim at (alternative way of setting the camera angle)"
 ]
 
 @PointClass = info_intermissiontext : "Intermission Text
@@ -2662,6 +2663,7 @@ Check each field's description for more details.
 		2: "Ignore intermissiontext" : 0
 		8: "Start Off" : 0
 		16: "Use info_player_start2" : 0
+		32: "Triggered, not touched" : 0
 	]
 	target(string) : "Specific intermission camera to use (works only if matching an info_intermission's targetname), otherwise a regular target to fire"
 ]

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -2220,6 +2220,7 @@ If the target entity changes its default behavior when 'targetname' is set (such
 [
 	wait(integer) : "is the average delay between bursts (variance is 1/2 wait). Default is 2."
 	cnt(integer) : "is the average number of sparks in a burst (variance is 1/4 cnt). Default is 15."
+	movedir(string) : "is the average vector distance that the sparks will travel before disappearing. (in x y z)" : "-40 -40 -40"
 	sounds(integer) : "set to 1 for built-in spark sound effect. Default is 0 - silent."
 	noise(string) : "Path to custom spark sound, requires 'sounds' be set to 1"
 	spawnflags(flags) =

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -3513,8 +3513,9 @@ delay how much time to wait before firing after being switched on."
 	angles(string) : "Angles (x y z)"
 	rotate(string) : "Rotate (x y z)"
 	noise1(string) : "Custom door start noise"
-	noise2(string) : "Custom door move noise"
+	noise2(string) : "Custom door opening noise"
 	noise3(string) : "Custom door stop noise"
+	noise4(string) : "Custom door closing noise (identical to opening noise if not set)"
 	sounds(choices) : "Sound" : 1 =
 	[
 		0: "None"

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -2024,6 +2024,13 @@ Originally unused in the game. Plays the sound of thunder at a random interval. 
 		16: "Silver Key required" : 0
 		32: "Toggle" : 0
 		64: "Doom-style Unlock" : 0
+		128: "Staged targets" : 0 : "
+target fired when the door starts opening,
+target2 fired when the door is open,
+target3 fired when the door starts closing,
+target4 fired when the door is closed
+killtarget & killtarget2 never fired; use a relay instead.
+"
 	]
 	_switchableshadow(choices) : "Switchable shadow" : 0 : "Enables dynamic shadows that fade on/off when the door moves." = [
 		0: "No"

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -373,6 +373,7 @@ the bprint tends to stomp any other prints on screen in most quake clients, so u
 		32 : "Spawn Silently" : 0
 		64 : "Trigger spawned" : 0
 		128 : "Suspended in air" : 0
+		131072 : "Spawn at player's position" : 0
 		4194304 : "Spawn then drop" : 0
 		8388608 : "Don't drop to floor" : 0
 	]

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -1447,7 +1447,13 @@ spawnflags(Flags) =
 // misc
 //
 
-@SolidClass base(Appearflags, ModelLight) = func_illusionary : "Static nonsolid model"  [ targetname(target_source) : "Name" : : "Useful for stealth teleportation only (see wiki)"]
+@SolidClass base(Appearflags, ModelLight) = func_illusionary : "Static nonsolid model"
+[
+	targetname(target_source) : "Name" : : "Useful to serve 
+* as a stealth teleportation destination (see wiki)
+* as an invisible non solid target for trigger_look (paint with SKIP texture)
+"
+]
 
 @PointClass base(Appearflags) color(0 150 220) model({ "path": ":progs/s_bubble.spr" }) = air_bubbles : "Air bubbles" []
 @PointClass base(Appearflags, Targetname) = event_lightning : "Chthon's lightning"

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -4077,6 +4077,7 @@ Finally, you can set the force of the magnet to be applied at a constant rate ra
 		1 : "Start Off" : 0
 		2 : "Linear" : 0 : "Don't square the force; force is applied at a constant rate."
 		4 : "No monsters" : 0 : "Don't affect monsters."
+		8 : "No items" : 0 : "Don't affect pickups."
 	]
 ]
 

--- a/fgd_def/remobilize.fgd
+++ b/fgd_def/remobilize.fgd
@@ -2875,12 +2875,13 @@ Don't forget that buttons targeting a counter should always be wait|-1 anyway, n
 	message2(string) : "Message when sequence completed in the wrong order"
 	pain_target(string) : "Fire this target when sequence completed in the wrong order"
 ]
-@SolidClass base(Angle, Appearflags, Targetname, TriggerWait) = trigger_push : "Trigger: Push"
+@SolidClass base(Angle, Appearflags, Targetname, TriggerWait, Homing) = trigger_push : "Trigger: Push"
 [
 	spawnflags(flags) =
 	[
 		1: "Push once" : 0
 		16: "Silent" : 0
+		32: "Don't hinder" : 0 : "Push the player or monster only if they facing the pushing direction. Adjust the accuracy with 'homing'"
 	]
 	speed(integer) : "Speed" : 1000
 ]

--- a/fight.qc
+++ b/fight.qc
@@ -392,6 +392,11 @@ float() ShamCheckAttack =
 	if (!enemy_vis)
 		return FALSE;
 
+	if (self.style == /*Melee only*/ 2)
+	{
+		return FALSE;
+	}
+
 	targ = self.enemy;
 
 // see if any entities are in the way of the shot
@@ -400,17 +405,17 @@ float() ShamCheckAttack =
 
 
 	if (self.style == 0)
-		{
-			if (vlen(spot1 - spot2) > 600)
-			return FALSE;
-		}
-		if (self.spawnflags & I_AM_TURRET)
-		{
-			if (vlen(spot1 - spot2) > 900)
-			return FALSE;
-		}
+	{
+		if (vlen(spot1 - spot2) > 600)
+		return FALSE;
+	}
+	if (self.spawnflags & I_AM_TURRET)
+	{
+		if (vlen(spot1 - spot2) > 900)
+		return FALSE;
+	}
 
-		// return FALSE;
+	// return FALSE;
 
 	traceline (spot1, spot2, FALSE, self);
 

--- a/fight.qc
+++ b/fight.qc
@@ -379,6 +379,11 @@ float() ShamCheckAttack =
 		}
 	}
 
+	if (self.style == /*Melee only*/ 2)
+	{
+		return FALSE;
+	}
+
 	if (self.spawnflags & I_AM_TURRET)
 		{
 			self.attack_state = AS_MISSILE;
@@ -391,11 +396,6 @@ float() ShamCheckAttack =
 
 	if (!enemy_vis)
 		return FALSE;
-
-	if (self.style == /*Melee only*/ 2)
-	{
-		return FALSE;
-	}
 
 	targ = self.enemy;
 

--- a/fteqcc.ini
+++ b/fteqcc.ini
@@ -201,7 +201,7 @@ log           off                       # Write out a compile log
 enginebinary  c:\Quake\fteqw64.exe      # Location of the engine binary to run. Change this to something
                                         # else to run a different engine, but not all support debugging.
 basedir       c:\Quake                  # The base directory of the game that contains your sub directory
-engineargs    "-game remobilize_test4 +exec fte.cfg +map rm_memory" 
+engineargs    "-game remobilize_test4 +exec fte.cfg +map DevilSwitch" 
                                         # The engine commandline to use when debugging. You'll likely want
                                         # to ensure this contains -window as well as the appropriate -game
                                         # argument.

--- a/fteqcc.ini
+++ b/fteqcc.ini
@@ -38,8 +38,7 @@ optimisation  cj            default     # This optimisation plays an effect most
                                         # instead of jumping to an unconditional jump statement, it'll jump
                                         # to the final destination instead. This will bewilder decompilers.
 optimisation  sf            default     # Strips out the 'defs' of functions that were only ever called
-                                        # directly. This does not affect saved games, but will prevent FTE_MULTIPROGS/mutators
-                                        # from being able to hook functions.
+                                        # directly. This does not affect saved games. This can affect FTE_MULTIPROGS.
 optimisation  lo            default     # Store all locals in a single section of the pr_globals. Vastly
                                         # reducing it. This effectivly does the job of overlaptemps.
                                         # However, locals are no longer automatically initialised to 0 (and
@@ -55,10 +54,6 @@ optimisation  vc            default     # Where a function is called with just a
 optimisation  cf            default     # Strip class field names. This will harm debugging and can result
                                         # in 'gibberish' names appearing in saved games. Has no effect on
                                         # engines other than FTEQW, which will not recognise these anyway.
-optimisation  uf            default     # Strips any fields that have no references. This may result in
-                                        # extra warnings at load time, or disabling support for mapper-specified
-                                        # alpha in engines that do not provide that. FIXME: this is a little
-                                        # pointless until relocs are properly implemented.
 keyword       asm           true        # Disables the 'asm' keyword. Use the writeasm flag to see an example
                                         # of the asm.
 keyword       break         true        # Disables the 'break' keyword.
@@ -119,19 +114,6 @@ keyword       var           true        # Disables the 'var' keyword.
 keyword       vector        true        # Disables the 'vector' keyword.
 keyword       wrap          true        # Disables the 'wrap' keyword.
 keyword       weak          true        # Disables the 'weak' keyword.
-keyword       accumulate    false       # Disables the 'accumulate' keyword.
-flag          acc           false       # Reacc is a pascall like compiler. It was released before the Quake
-                                        # source was released. This flag has a few effects. It sorts all
-                                        # qc files in the current directory into alphabetical order to compile
-                                        # them. It also allows Reacc global/field distinctions, as well
-                                        # as allows | for linebreaks. Whilst case insensitivity and lax
-                                        # type checking are supported by reacc, they are seperate compiler
-                                        # flags in fteqcc.
-flag          qccx          false       # WARNING: This syntax makes mods inherantly engine specific.
-                                        # Do NOT use unless you know what you're doing.This is provided
-                                        # for compatibility only
-                                        # Any entity hacks will be unsupported in FTEQW, DP, and others,
-                                        # resulting in engine crashes if the code in question is executed.
 flag          kce           true        # If you want keywords to NOT be disabled when they a variable by
                                         # the same name is defined, check here.
 flag          parms         false       # if PARM0 PARM1 etc should be defined by the compiler. These are
@@ -161,6 +143,12 @@ flag          brokenarray   false       # Treat references to arrays as referenc
                                         # said array, to replicate an old fteqcc bug.
 flag          rootconstructor false     # When enabled, the root constructor should be called first like
                                         # in c++.
+flag          acc           false       # Reacc is a pascall like compiler. It was released before the Quake
+                                        # source was released. This flag has a few effects. It sorts all
+                                        # qc files in the current directory into alphabetical order to compile
+                                        # them. It also allows Reacc global/field distinctions, as well
+                                        # as allows ¦ as EOF. Whilst case insensitivity and lax type checking
+                                        # are supported by reacc, they are seperate compiler flags in fteqcc.
 flag          caseinsens    false       # Causes fteqcc to become case insensitive whilst compiling names.
                                         # It's generally not advised to use this as it compiles a little
                                         # more slowly and provides little benefit. However, it is required
@@ -199,40 +187,28 @@ flag          subscope      false       # Restrict the scope of locals to the bl
 flag          verbose       false       # Lots of extra compiler messages.
 flag          typeexplicit  false       # All type conversions must be explicit or directly supported by
                                         # instruction set.
-flag          boundchecks   true        # Disable array index checks, speeding up array access but can result
+flag          noboundchecks false       # Disable array index checks, speeding up array access but can result
                                         # in your code misbehaving.
-flag          attributes    false       # WARNING: This syntax conflicts with vector constructors.
-flag          assumevar     false       # Initialised globals will be considered non-const by default.
-flag          ssp           false       # Treat ** as an operator for exponents, instead of multiplying
-                                        # by a dereferenced pointer.
-flag          cpriority     false       # QC treats !a&&b as equivelent to !(a&&b). When this is set, behaviour
-                                        # will be (!a)&&b as in C. Other operators are also affected in
-                                        # similar ways.
-flag          allowuninit   false       # Permit optimisations that may result in locals being uninitialised.
-                                        # This may allow for greater reductions in temps.
-flag          nofileline    false       # Ignores #pragma file(foo) and #pragma line(foo), so that errors
-                                        # and symbols reflect the actual lines, instead of the original
-                                        # source.
-flag          utf8          false       # String immediates will use utf-8 encoding, instead of quake's
-                                        # encoding.
-flag          embedsrc      false       # Write the sourcecode into the output file. The resulting .dat
-                                        # can be opened as a standard zip archive (or by fteqccgui).
-                                        # Good for GPL compliance!
+flag          qccx          false       # WARNING: This syntax makes mods inherantly engine specific.
+                                        # Do NOT use unless you know what you're doing.This is provided
+                                        # for compatibility only
+                                        # Any entity hacks will be unsupported in FTEQW, DP, and others,
+                                        # resulting in engine crashes if the code in question is executed.
+flag          embedsrc      false       # Write the sourcecode into the output file.
 showall       off                       # Show all keyword options in the gui
 compileonstart off                      # Recompile on GUI startup
 log           off                       # Write out a compile log
-enginebinary  d:\Quakec\fteqw64.exe     # Location of the engine binary to run. Change this to something
+enginebinary  c:\Quake\fteqw64.exe      # Location of the engine binary to run. Change this to something
                                         # else to run a different engine, but not all support debugging.
-basedir       d:\Quakec                 # The base directory of the game that contains your sub directory
-engineargs    "-game progs_dump +exec fte.cfg" 
+basedir       c:\Quake                  # The base directory of the game that contains your sub directory
+engineargs    "-game remobilize_test4 +exec fte.cfg +map rm_memory" 
                                         # The engine commandline to use when debugging. You'll likely want
                                         # to ensure this contains -window as well as the appropriate -game
                                         # argument.
 srcfile       progs.src                 # The progs.src file to load to find ordering of other qc files.
 src                                     # Additional subdir to read qc files from. Typically blank (ie:
                                         # the working directory).
-tabsize       8                         # Specifies the size of tabs in scintilla windows.
-extramargins  off                       # Enables line number and folding margins.
+extramargins  on                        # Enables line number and folding margins.
 hexen2        off                       # Enable the extra tweaks needed for compatibility with hexen2 engines.
 extendedopcodes off                     # Utilise an extended instruction set, providing support for pointers
                                         # and faster arrays and other speedups.

--- a/hippart.qc
+++ b/hippart.qc
@@ -251,7 +251,8 @@ void () blocker_touch =
 
 void MoveEntityOrigin(entity t, vector offset)
 {
-	setorigin(t, t.origin + offset);
+	t.origin = t.origin + offset;
+	setorigin(t, t.origin);
 }
 
 void MoveTargetOrigin(string value, .string tname_field)

--- a/hiptrig.qc
+++ b/hiptrig.qc
@@ -24,7 +24,23 @@ keytrigger_use function.  -- iw
 */
 void() keytrigger_unlock =
 {
+	float omessage0, omessage20;
+	if (self.message == "0")
+	{
+		omessage0 = TRUE;
+		self.message = "";
+	}
+	if (self.message2 == "0")
+	{
+		omessage20 = TRUE;
+		self.message2 = "";
+	}
+	
 	SUB_UseTargets();
+	
+	if (omessage0) self.message = "0";
+	if (omessage20) self.message2 = "0";
+
 	self.estate = STATE_INACTIVE;
 };
 

--- a/intermission.qc
+++ b/intermission.qc
@@ -16,10 +16,23 @@ entity used_exit;
 This is the camera point for the intermission.
 Use mangle instead of angle, so you can set pitch or roll as well as yaw.  'pitch roll yaw'
 */
+void() SetIntermissionMangle =
+{
+	entity t = find(world,targetname,self.target);
+	self.mangle = vectoangles(t.origin - self.origin);
+	self.mangle_x = -self.mangle_x;
+};
+
 void() info_intermission =
 {
 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
 		return;
+		
+	if (self.target)
+	{
+		self.think = SetIntermissionMangle;
+		self.nextthink = self.ltime + 0.2;
+	}
 };
 
 
@@ -416,6 +429,12 @@ void() dt_exit_toggle = //dumptruck_ds based on hipnotic blocker_use
 	}
 };
 
+void() exit_use =
+{
+	other = find(world,classname,"player");
+	if (!other) other = find(world,classname,"camera");
+	changelevel_touch();
+};
 
 float DT_EXITOFF = 8;
 /*QUAKED trigger_changelevel (0.5 0.5 0.5) ? NO_INTERMISSION X X X X X X X NOT_ON_EASY NOT_ON_NORMAL NOT_ON_HARD_OR_NIGHTMARE NOT_IN_DEATHMATCH NOT_IN_COOP NOT_IN_SINGLEPLAYER X NOT_ON_HARD_ONLY NOT_ON_NIGHTMARE_ONLY
@@ -436,12 +455,21 @@ void() trigger_changelevel =
 	if (!self.sounds)
 		self.sounds = 3;
 	
-	self.use = dt_exit_toggle;
 	if (!self.map)
 		objerror ("changelevel trigger doesn't have map");
 
 
 	InitTrigger ();
 	self.flags = self.flags | FL_NOCENTERPRINT;
-	self.touch = changelevel_touch;
+	
+	if (self.spawnflags & /*Triggered, not touched*/ 32)
+	{
+		self.touch = SUB_Null;
+		self.use = exit_use;
+	}
+	else
+	{
+		self.touch = changelevel_touch;
+		self.use = dt_exit_toggle;
+	}
 };

--- a/items.qc
+++ b/items.qc
@@ -6,6 +6,7 @@ BE .8 .3 .4 IN COLOR */
 float ITEM_SPAWNSILENT = 32;
 float ITEM_SPAWNED = 64;
 float ITEM_SUSPENDED = 128;
+float ITEM_AT_PLAYER_ORIGIN = 131072;
 float ITEM_RESPAWNDM = 16384;
 float ITEM_SPAWNFALL = 4194304;
 float ITEM_DONTDROP = 8388608;
@@ -93,6 +94,12 @@ void() DropToFloor = { droptofloor(); }
 
 void() DelaySpawnItem =
 {
+	if (self.spawnflags & ITEM_AT_PLAYER_ORIGIN)
+	{
+		entity player = find(world,classname,"player");
+		if (player) setorigin (self, player.origin);
+	}
+	
 	self.solid = SOLID_TRIGGER;
 	setmodel (self, self.mdl);
 	resize(self.pos1, self.pos2);

--- a/magnets.qc
+++ b/magnets.qc
@@ -15,7 +15,11 @@ void() magnet_touch =
 	{
 		return;
 	}
-		
+	
+	
+	if (other.flags & FL_ITEM && self.spawnflags & /*No items*/ 8)
+		return;
+	
 	local vector disp;
 	local float dist, inv_dist_squared, force;
 	

--- a/misc.qc
+++ b/misc.qc
@@ -1836,7 +1836,7 @@ void() target_textstory_helper_show = {
 
 	textstory_show(self.owner);
 
-	if (self.attack_finished < time) self.think = target_textstory_helper_hide;
+	if (self.attack_finished < time || self.owner.estate != STATE_ACTIVE) self.think = target_textstory_helper_hide;
 
 	self.nextthink = time + 0.1;
 };

--- a/rotate.qc
+++ b/rotate.qc
@@ -1107,15 +1107,15 @@ void() rotate_door_use =
       start = self.dest1;
       self.dest = self.dest2;
       self.state = STATE_OPENING;
+	  sound(self, CHAN_VOICE, self.noise2, 1, ATTN_NORM);
       }
    else
       {
       start = self.dest2;
       self.dest = self.dest1;
       self.state = STATE_CLOSING;
+	  sound(self, CHAN_VOICE, self.noise4, 1, ATTN_NORM);
       }
-
-   sound(self, CHAN_VOICE, self.noise2, 1, ATTN_NORM);
 
    self.rotate = ( self.dest - start ) * ( 1 / self.speed );
    self.think = rotate_door_think;
@@ -1208,9 +1208,11 @@ void() func_rotate_door = // added slinet option - sounds 4 -- dumptruck_ds
   {
       self.noise1 = self.noise2 = self.noise3 = "misc/null.wav";
   }
+  if (!self.noise4) self.noise4 = self.noise2;
    precache_sound (self.noise1);
    precache_sound (self.noise2);
    precache_sound (self.noise3);
+   precache_sound (self.noise4);
    
    self.solid = SOLID_NOT;
    self.movetype = MOVETYPE_NONE;

--- a/rubicon2.qc
+++ b/rubicon2.qc
@@ -810,9 +810,9 @@ void() make_sparks =
 			spark.movetype = MOVETYPE_BOUNCE;
 			spark.solid = SOLID_TRIGGER;
 			spark.gravity = 0.3;
-			spark.velocity_x = -40 + random() * 80;
-			spark.velocity_y = -40 + random() * 80;
-			spark.velocity_z = -40 + random() * 80;
+			spark.velocity_x = self.movedir_x + random() * 80;
+			spark.velocity_y = self.movedir_y + random() * 80;
+			spark.velocity_z = self.movedir_z + random() * 80;
 			spark.avelocity = '3000 3000 3000';
 			spark.nextthink = time + 0.5 + 1.5*random();
 			spark.think = sparks_fade1;
@@ -880,7 +880,7 @@ void() misc_sparks =
 	precache_sound (self.noise);
 
 	if (!self.movedir)
-		self.movedir = '0 0 -30';
+		self.movedir = '-40 -40 -40';
 	if (!self.wait)
 		self.wait = 2;
 	if (!self.cnt)

--- a/rubicon2.qc
+++ b/rubicon2.qc
@@ -343,7 +343,12 @@ void () func_breakable_die = {
 	// this is to ensure that any debris from another func_breakable
 	// which is resting on top of this func_breakable is not left
 	// floating in mid-air after this entity is removed -- iw
-	SUB_DislodgeRestingEntities ();
+	if (DislodgeManager == world)
+	{
+		DislodgeManager = spawn();
+		DislodgeManager.think = SUB_DislodgeRestingEntities;
+	}
+	DislodgeManager.nextthink = time + 1;
 
 	if (self.visitflag & BREAK_EXPLODE) {
 		if (self.visitflag & BREAK_CUSTOM) {

--- a/shambler.qc
+++ b/shambler.qc
@@ -686,9 +686,9 @@ void() monster_shambler =
 	else
 	self.th_melee = sham_melee;
 	if (self.style == 1)
-	self.th_missile = sham_proj1;
-	else
-	self.th_missile = sham_magic1;
+		self.th_missile = sham_proj1;
+	else if (self.style != 2)
+		self.th_missile = sham_magic1;
 	if (self.style == 1)
 	self.th_turret = sham_turret_proj1;
 	else

--- a/subs.qc
+++ b/subs.qc
@@ -766,6 +766,8 @@ self is going to be removed, to ensure that other entities are not left
 floating.  -- iw
 ================
 */
+entity DislodgeManager;
+
 void() SUB_DislodgeRestingEntities =
 {
 	local entity e;

--- a/subs.qc
+++ b/subs.qc
@@ -393,11 +393,23 @@ void() SUB_UseTargets =
 	if (self.message != "" && !(self.flags & FL_NOCENTERPRINT) && self != world) {
 		if (self.spawnflags & TRIGGER_CENTERPRINTALL) {
 			t = find(world, classname, "player");
-			while (t) {
-				centerprint (t, self.message);
-				if (!self.noise)
-					sound (t, CHAN_VOICE, "misc/talk.wav", 1, ATTN_NORM);
-				t = find(t, classname, "player");
+			if(t)
+				while (t)
+				{
+					centerprint (t, self.message);
+					if (!self.noise)
+						sound (t, CHAN_VOICE, "misc/talk.wav", 1, ATTN_NORM);
+					t = find(t, classname, "player");
+				}
+			else
+			{
+				t = find(world, classname, "camera");
+				if(t)
+				{
+					centerprint (t, self.message);
+					if (!self.noise)
+						sound (t, CHAN_VOICE, "misc/talk.wav", 1, ATTN_NORM);
+				}
 			}
 		}
 		

--- a/triggers.qc
+++ b/triggers.qc
@@ -1853,7 +1853,7 @@ void(entity e, float state, float flags) entity_set_state = {
 		if (state == STATE_ACTIVE) door_estate_unlock(e, closealldoors);
 		else door_estate_lock(e, closealldoors);
 	}
-	else if(e.classname == "func_togglevisiblewall") {
+	else if(e.classname == "func_togglevisiblewall" && state != entity_get_state(e)) {
 		tempself = self;
 		self = e;
 		e.estate = state;

--- a/triggers.qc
+++ b/triggers.qc
@@ -813,9 +813,30 @@ void() info_teleport_random =
 
 void() teleport_use =
 {
+	entity e = world;
+
 	self.nextthink = time + 0.2;
-	force_retouch = 2;		// make sure even still objects get hit
 	self.think = SUB_Null;
+
+	if(self.include)
+	{
+		//Programmatically teleport someone no matter where they initially are
+		//Let's find the first entity matching the condition (no more than one, otherwise they'd telefrag)
+		if (!e)	for (e = world; (e = find(e, targetname,  self.include)); ) if (e.health > 0) break;
+		if (!e)	for (e = world; (e = find(e, targetname2, self.include)); ) if (e.health > 0) break;
+		if (!e)	for (e = world; (e = find(e, targetname3, self.include)); ) if (e.health > 0) break;
+		if (!e)	for (e = world; (e = find(e, targetname4, self.include)); ) if (e.health > 0) break;
+	}
+	
+	if (e)
+	{
+		other = e;
+		teleport_touch();
+	}
+	else
+	{
+		force_retouch = 2;		// make sure even still objects get hit
+	}
 };
 
 // -------------------------

--- a/triggers.qc
+++ b/triggers.qc
@@ -1815,7 +1815,7 @@ float(entity e) entity_get_state = {
 		return !(e.spawnflags & LT_ACTIVE);
 	else if(e.classname == "light")
 		return e.spawnflags & START_OFF;
-	else if(e.classname == "togglewall")
+	else if(e.classname == "togglewall" || e.classname == "play_sound_triggered")
 		return 1 - e.state;
 	else
 		return e.estate;
@@ -1865,6 +1865,12 @@ void(entity e, float state, float flags) entity_set_state = {
 		tempself = self;
 		self = e;
 		light_use();
+		self = tempself;
+	}
+	else if(e.classname == "play_sound_triggered" && state != entity_get_state(e)) {
+		tempself = self;
+		self = e;
+		play_sound_use();
 		self = tempself;
 	}
 	else e.estate = state;

--- a/triggers.qc
+++ b/triggers.qc
@@ -1826,10 +1826,13 @@ void(entity e, float state, float flags) entity_set_state = {
 	float closealldoors;
 
 	if(e.classname == "trigger_teleport") {
-		if (state == STATE_ACTIVE)
-			sound (e, CHAN_WEAPON, "ambience/hum1.wav", 0.5, ATTN_NORM);
-		else
-			sound (e, CHAN_WEAPON, "misc/null.wav", 0.5, ATTN_NORM);
+		if (!(self.spawnflags & SILENT))
+		{
+			if (state == STATE_ACTIVE)
+				sound (e, CHAN_WEAPON, "ambience/hum1.wav", 0.5, ATTN_NORM);
+			else
+				sound (e, CHAN_WEAPON, "misc/null.wav", 0.5, ATTN_NORM);
+		}
 		e.estate = state;
 	}
 	else if(e.classname == "func_button") {

--- a/triggers.qc
+++ b/triggers.qc
@@ -2698,5 +2698,5 @@ void() trigger_startup =
 	self.think = startup_think;
 	// No need for a use function, as this entity does not need to be targeted due to being automatically activated
 	self.estate = STATE_ACTIVE;
-	self.nextthink = time;
+	self.nextthink = time + 0.2; //A slight delay is applied to be sure all the other entities have spawned
 };

--- a/triggers.qc
+++ b/triggers.qc
@@ -2506,7 +2506,7 @@ void() trigger_enterleave_leave =
 		return;
 
     self.wait = 0;
-	if (self.target3!="" || self.target4!="")
+	if (self.target3!="" || self.target4!="" || self.killtarget2!="")
 	{
 		string otarget = self.target;
 		string otarget2 = self.target2;
@@ -2530,7 +2530,7 @@ void() trigger_enterleave_enter =
     if (self.wait == 0) // first touch?
     {
         self.wait = 1;
-		if (self.target!="" || self.target2!="")
+		if (self.target!="" || self.target2!="" || self.killtarget!="")
         {
 			string otarget3 = self.target3;
 			string otarget4 = self.target4;

--- a/triggers.qc
+++ b/triggers.qc
@@ -1427,7 +1427,19 @@ void() onlookat_think =
 		
 		for (entity e = world; (e = find(e, targetname, self.target)); )
 		{
+			if(e.classname == "func_illusionary")
+			{
+				//Make solid for the trace check
+				e.solid = SOLID_BSP;
+				e.movetype = MOVETYPE_PUSH;
+			}
 			traceline(player_offset, (e.mins + e.maxs) * 0.5, 1, other);
+			if(e.classname == "func_illusionary")
+			{
+				//Return to normal state
+				e.solid = SOLID_NOT;
+				e.movetype = MOVETYPE_NONE;
+			}
 			if (trace_ent == e)
 			{
 				success = TRUE;
@@ -1438,7 +1450,19 @@ void() onlookat_think =
 		if(!success)
 		for (entity e = world; (e = find(e, targetname2, self.target)); )
 		{
+			if(e.classname == "func_illusionary")
+			{
+				//Make solid for the trace check
+				e.solid = SOLID_BSP;
+				e.movetype = MOVETYPE_PUSH;
+			}
 			traceline(player_offset, (e.mins + e.maxs) * 0.5, 1, other);
+			if(e.classname == "func_illusionary")
+			{
+				//Return to normal state
+				e.solid = SOLID_NOT;
+				e.movetype = MOVETYPE_NONE;
+			}
 			if (trace_ent == e)
 			{
 				success = TRUE;
@@ -1449,7 +1473,19 @@ void() onlookat_think =
 		if(!success)
 		for (entity e = world; (e = find(e, targetname3, self.target)); )
 		{
+			if(e.classname == "func_illusionary")
+			{
+				//Make solid for the trace check
+				e.solid = SOLID_BSP;
+				e.movetype = MOVETYPE_PUSH;
+			}
 			traceline(player_offset, (e.mins + e.maxs) * 0.5, 1, other);
+			if(e.classname == "func_illusionary")
+			{
+				//Return to normal state
+				e.solid = SOLID_NOT;
+				e.movetype = MOVETYPE_NONE;
+			}
 			if (trace_ent == e)
 			{
 				success = TRUE;
@@ -1460,7 +1496,19 @@ void() onlookat_think =
 		if(!success)
 		for (entity e = world; (e = find(e, targetname4, self.target)); )
 		{
+			if(e.classname == "func_illusionary")
+			{
+				//Make solid for the trace check
+				e.solid = SOLID_BSP;
+				e.movetype = MOVETYPE_PUSH;
+			}
 			traceline(player_offset, (e.mins + e.maxs) * 0.5, 1, other);
+			if(e.classname == "func_illusionary")
+			{
+				//Return to normal state
+				e.solid = SOLID_NOT;
+				e.movetype = MOVETYPE_NONE;
+			}
 			if (trace_ent == e)
 			{
 				success = TRUE;
@@ -1477,9 +1525,20 @@ void() onlookat_think =
 		//using speed to determine the reach of the trace
 		if(!self.speed)
 			self.speed = 500;
+		
 		traceline(player_offset, (player_offset + (v_forward * self.speed)), FALSE, other);
 		
 		success = (trace_ent.targetname == self.target || trace_ent.targetname2 == self.target || trace_ent.targetname3 == self.target || trace_ent.targetname4 == self.target);
+		
+		if(!success)
+		{
+			//Now let's redo the check including illusionaries
+			MakeClassSolid("func_illusionary",TRUE);
+			traceline(player_offset, (player_offset + (v_forward * self.speed)), FALSE, other);
+			MakeClassSolid("func_illusionary",FALSE);
+			
+			success = (trace_ent.targetname == self.target || trace_ent.targetname2 == self.target || trace_ent.targetname3 == self.target || trace_ent.targetname4 == self.target);
+		}
 	}
 
     if (success)

--- a/triggers.qc
+++ b/triggers.qc
@@ -1042,8 +1042,16 @@ void() trigger_push_touch =
 		other.velocity = self.speed * self.movedir * 10;
 	else if (other.health > 0)
 	{
+		// if the trigger has an angles field, check player's facing direction
+		if (self.spawnflags & /*Don't hinder*/ 32)
+		{
+			makevectors (other.angles);
+			if (!(v_forward * self.movedir >= self.homing)) //self.homing is the minimum accuracy; default is 0 (up to 90° away from the ideal direction); up to 1 (exactly the ideal direction, no compromise!)
+				return;		// not facing the right way
+		}
+	
 		other.velocity = self.speed * self.movedir * 10;
-		if (other.classname == "player")
+		
 		if (!(self.spawnflags & DT_SILENT))
 		{
 			if (other.fly_sound < time)


### PR DESCRIPTION
A bit as an afterthought after my work on trigger_look in the previous PR, but this time I think the way of handling non solid targets is perfect.
Instead of the clumsy func_playernoclip which came with its own restrictions and inconsistencies (while non solid to the player it is still solid to the rest of the world, so it weirdly blocks monster seeing and projectiles), now trigger_look work hand in hand with func_illusionary.
Player can eventually look in the thin air and get messages, thanks to trigger_look targeting a
* non solid (for player and monsters as well)
* invisible
* projectiles pass-through
* player & monsters see-through
target.
